### PR TITLE
fix(embeddings)!: use MLX on Python 3.14, embed documents raw per spec

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
-  - repo: https://github.com/lattice/ggshield
-    rev: v1.46.0
+  - repo: https://github.com/GitGuardian/ggshield
+    rev: v1.52.2
     hooks:
       - id: ggshield
         language_version: python3

--- a/src/kb/embeddings.py
+++ b/src/kb/embeddings.py
@@ -33,9 +33,22 @@ EMBEDDING_DIM = 1024
 # Safety cap: truncate at ~2000 tokens to prevent MPS OOM on long texts
 MAX_TEXT_CHARS = 8_000
 
-# Instruction-aware prompts (Qwen3 supports custom task instructions for +1-5% retrieval)
-INDEX_INSTRUCTION = "Represent this document section for retrieval"
+# Qwen3-Embedding is asymmetric: a query is wrapped in an instruction template,
+# a document is embedded as RAW text (per the model card: "no need to add
+# instruction for retrieval documents").  A per-task query instruction adds
+# +1-5% retrieval.  Both backends MUST format identically so their vectors are
+# interchangeable — see _format_query and the parity test.
 QUERY_INSTRUCTION = "Find meeting notes, transcripts, and documents relevant to this query"
+
+
+def _format_query(query: str) -> str:
+    """Wrap a search query in Qwen3's ``Instruct: {task}\\nQuery: {q}`` template.
+
+    Documents are never wrapped (they are embedded raw), so a query and the
+    document it should match land in the embedding space the model was trained
+    on.  Used identically by both backends.
+    """
+    return f"Instruct: {QUERY_INSTRUCTION}\nQuery: {query}"
 
 
 # ---------------------------------------------------------------------------
@@ -51,14 +64,20 @@ def _is_apple_silicon() -> bool:
 def _mlx_available() -> bool:
     """Return True if Apple Silicon AND mlx is importable.
 
-    MLX's C extension can fatal-abort (segfault) on unsupported Python
-    versions (e.g. 3.14+).  We guard with a version check first so the
-    process never reaches the C import.
+    MLX's C extension can fatal-abort (segfault) on a CPython release it has
+    not shipped wheels for yet, so we guard with a pre-import version check —
+    a catchable ImportError the try/except below would handle, but a segfault
+    it would not.
+
+    MLX 0.31.2+ ships cp314 wheels and runs correctly on Python 3.14 (verified
+    GPU compute + Qwen3 embedding parity), so the guard tracks the next
+    *untested* major, 3.15.  When mlx is merely absent or fails a catchable
+    import, the try/except falls back to PyTorch.
     """
     if not _is_apple_silicon():
         return False
-    # MLX doesn't yet support Python 3.14+; importing crashes at C level
-    if sys.version_info >= (3, 14):
+    # Pre-import canary: block only CPython releases MLX has no wheels for yet.
+    if sys.version_info >= (3, 15):
         return False
     try:
         import mlx.core  # noqa: F401
@@ -81,7 +100,6 @@ class _EmbedderBackend(Protocol):
         self,
         texts: list[str],
         batch_size: int | None = None,
-        instruction: str = INDEX_INSTRUCTION,
     ) -> npt.NDArray[np.float32]: ...
 
     def embed_query(self, query: str) -> npt.NDArray[np.float32]: ...
@@ -134,13 +152,13 @@ class _PyTorchBackend:
         self,
         texts: list[str],
         batch_size: int | None = None,
-        instruction: str = INDEX_INSTRUCTION,
     ) -> npt.NDArray[np.float32]:
-        """Embed a list of texts for indexing.
+        """Embed a list of documents for indexing.
 
         Returns L2-normalized float32 array of shape (n, 1024).
-        Uses instruction-aware embedding with configurable task instruction.
-        batch_size defaults to 64 on MPS, 32 on CPU.
+        Documents are embedded as raw text (empty prompt) per the Qwen3 model
+        card; only queries carry an instruction. batch_size defaults to 32 on
+        MPS, 16 on CPU.
 
         On MPS, processes batch_size texts per encode() call with cache
         cleanup between calls to work around the PyTorch MPS memory leak
@@ -162,7 +180,7 @@ class _PyTorchBackend:
                 # CPU or small batch: single encode() call is fine
                 embeddings = model.encode(
                     truncated,
-                    prompt=instruction,
+                    prompt="",
                     normalize_embeddings=True,
                     show_progress_bar=False,
                     batch_size=batch_size,
@@ -176,7 +194,7 @@ class _PyTorchBackend:
                 chunk = truncated[i : i + batch_size]
                 embs = model.encode(
                     chunk,
-                    prompt=instruction,
+                    prompt="",
                     normalize_embeddings=True,
                     show_progress_bar=False,
                     batch_size=batch_size,
@@ -192,7 +210,8 @@ class _PyTorchBackend:
         """Embed a search query.
 
         Returns L2-normalized float32 array of shape (1, 1024).
-        Uses query-specific instruction for better retrieval.
+        The query is wrapped in Qwen3's instruction template and encoded as
+        raw text (empty prompt) so it matches the raw-text document space.
         """
         import numpy as np
         import torch
@@ -200,8 +219,8 @@ class _PyTorchBackend:
         model = self._load()
         with torch.inference_mode():
             embeddings = model.encode(
-                [query],
-                prompt=QUERY_INSTRUCTION,
+                [_format_query(query)],
+                prompt="",
                 normalize_embeddings=True,
                 show_progress_bar=False,
             )
@@ -236,19 +255,18 @@ class _MLXBackend:
             self._tokenizer = tokenizer
         return self._model, self._tokenizer
 
-    def _tokenize_and_run(
-        self, texts: list[str], max_length: int = 512, instruction: str | None = None
-    ) -> npt.NDArray[np.float32]:
-        """Tokenize texts, run through the MLX model, return numpy float32."""
+    def _tokenize_and_run(self, texts: list[str], max_length: int = 512) -> npt.NDArray[np.float32]:
+        """Tokenize texts as-is, run through the MLX model, return numpy float32.
+
+        Callers pre-format their input: documents are passed raw, queries are
+        wrapped with ``_format_query`` before reaching here.
+        """
         import mlx.core as mx
         import numpy as np
 
         model, tokenizer = self._load()
-        formatted = (
-            [f"Instruct: {instruction}\nQuery: {t}" for t in texts] if instruction else texts
-        )
         encoded = tokenizer(
-            formatted,
+            texts,
             padding=True,
             truncation=True,
             max_length=max_length,
@@ -273,9 +291,8 @@ class _MLXBackend:
         self,
         texts: list[str],
         batch_size: int | None = None,
-        instruction: str = INDEX_INSTRUCTION,
     ) -> npt.NDArray[np.float32]:
-        """Embed texts using MLX. Returns L2-normalized float32 (n, 1024)."""
+        """Embed documents using MLX (raw text). Returns float32 (n, 1024)."""
         import numpy as np
 
         truncated = [t[:MAX_TEXT_CHARS] for t in texts]
@@ -286,7 +303,7 @@ class _MLXBackend:
         all_embeddings = []
         for i in range(0, len(truncated), batch_size):
             batch = truncated[i : i + batch_size]
-            all_embeddings.append(self._tokenize_and_run(batch, instruction=instruction))
+            all_embeddings.append(self._tokenize_and_run(batch))
             # Clear Metal cache between batches to prevent memory accumulation
             if len(truncated) > batch_size:
                 self.release_gpu_memory()
@@ -296,8 +313,8 @@ class _MLXBackend:
         return np.concatenate(all_embeddings, axis=0)
 
     def embed_query(self, query: str) -> npt.NDArray[np.float32]:
-        """Embed a search query with instruction prefix."""
-        return self._tokenize_and_run([query], instruction=QUERY_INSTRUCTION)
+        """Embed a search query wrapped in Qwen3's instruction template."""
+        return self._tokenize_and_run([_format_query(query)])
 
     def release_gpu_memory(self) -> None:
         """Clear MLX Metal cache to release unified memory."""
@@ -358,13 +375,12 @@ class Embedder:
         self,
         texts: list[str],
         batch_size: int | None = None,
-        instruction: str = INDEX_INSTRUCTION,
     ) -> npt.NDArray[np.float32]:
-        """Embed a list of texts for indexing.
+        """Embed a list of documents for indexing (raw text, no instruction).
 
         Returns L2-normalized float32 array of shape (n, 1024).
         """
-        return self._get_backend().embed(texts, batch_size=batch_size, instruction=instruction)
+        return self._get_backend().embed(texts, batch_size=batch_size)
 
     def embed_query(self, query: str) -> npt.NDArray[np.float32]:
         """Embed a search query.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,9 +42,22 @@ def _offline_and_no_socks_proxy():
 
 
 def _model_cached() -> bool:
-    """Return True if Qwen3-Embedding-0.6B is in the local HF cache."""
-    hf_cache = Path.home() / ".cache" / "huggingface" / "hub"
-    return (hf_cache / "models--Qwen--Qwen3-Embedding-0.6B").is_dir()
+    """Return True if Qwen3-Embedding-0.6B is available locally.
+
+    kbx stores the model under its own data dir (``get_data_dir()/model`` in HF
+    snapshot layout) — that is where the Embedder loads it from, so check there
+    first.  Fall back to the default HF hub cache for environments that
+    downloaded it there instead.
+    """
+    rel = "models--Qwen--Qwen3-Embedding-0.6B"
+    candidates = [Path.home() / ".cache" / "huggingface" / "hub" / rel]
+    try:
+        from kb.config import get_data_dir
+
+        candidates.insert(0, get_data_dir() / "model" / rel)
+    except Exception:
+        pass
+    return any(c.is_dir() for c in candidates)
 
 
 requires_model = pytest.mark.skipif(

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -107,6 +107,54 @@ class TestEmbeddingOutput:
         np.testing.assert_allclose(norms, 1.0, atol=0.02)
 
 
+@pytest.mark.slow
+class TestBackendParity:
+    """MLX and PyTorch must produce interchangeable vectors, so a backend
+    switch (Python 3.13<->3.14, mlx present<->absent) never silently corrupts
+    an existing index. Documents and queries are checked separately.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _requires_mlx_and_model(self):
+        import importlib.util
+
+        from conftest import _model_cached
+
+        from kb.embeddings import _is_apple_silicon
+
+        if not _is_apple_silicon() or importlib.util.find_spec("mlx") is None:
+            pytest.skip("Backend parity needs Apple Silicon with mlx")
+        if not _model_cached():
+            pytest.skip("Qwen3 model not cached locally")
+
+    def test_documents_and_queries_match_across_backends(self):
+        import numpy as np
+
+        from kb.config import get_data_dir
+        from kb.embeddings import _MLXBackend, _PyTorchBackend
+
+        cache = get_data_dir() / "model"
+        docs = [
+            "MFA rollout status for the secrets manager squad",
+            "Quarterly goal validation for the data platform team",
+        ]
+        query = "multi-factor authentication progress"
+
+        mlx_doc = _MLXBackend(cache).embed(docs)
+        pt_doc = _PyTorchBackend(cache, "cpu").embed(docs)
+        mlx_q = _MLXBackend(cache).embed_query(query)
+        pt_q = _PyTorchBackend(cache, "cpu").embed_query(query)
+
+        def cos(a, b):
+            return float(np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b)))
+
+        for i in range(len(docs)):
+            sim = cos(mlx_doc[i], pt_doc[i])
+            assert sim > 0.99, f"document {i} diverges across backends: cosine={sim:.4f}"
+        sim_q = cos(mlx_q[0], pt_q[0])
+        assert sim_q > 0.99, f"query diverges across backends: cosine={sim_q:.4f}"
+
+
 class TestPlatformHelpers:
     def test_is_apple_silicon_returns_bool(self):
         from kb.embeddings import _is_apple_silicon
@@ -133,6 +181,89 @@ class TestPlatformHelpers:
                 importlib.reload(kb.embeddings)
                 assert not kb.embeddings._mlx_available()
                 importlib.reload(kb.embeddings)  # restore
+
+
+class TestMLXVersionGuard:
+    """The pre-import version guard should track the *next* untested CPython.
+
+    MLX 0.31.2+ ships cp314 wheels and runs correctly on Python 3.14, so 3.14
+    must NOT be blocked. The guard exists only to pre-empt a C-level segfault on
+    a CPython release MLX has not built wheels for yet — currently 3.15+.
+    """
+
+    @pytest.fixture
+    def _fake_mlx_core(self):
+        """Inject a fake mlx.core so `import mlx.core` succeeds everywhere."""
+        from types import ModuleType
+
+        fake_core = ModuleType("mlx.core")
+        fake_mlx = ModuleType("mlx")
+        fake_mlx.core = fake_core  # type: ignore[attr-defined]
+        originals = {k: sys.modules.get(k) for k in ("mlx", "mlx.core")}
+        sys.modules["mlx"] = fake_mlx
+        sys.modules["mlx.core"] = fake_core
+        yield
+        for k, v in originals.items():
+            if v is None:
+                sys.modules.pop(k, None)
+            else:
+                sys.modules[k] = v
+
+    def test_allows_python_314(self, _fake_mlx_core):
+        """Python 3.14 is supported by MLX and must be allowed."""
+        from kb.embeddings import _mlx_available
+
+        with (
+            patch("kb.embeddings._is_apple_silicon", return_value=True),
+            patch.object(sys, "version_info", (3, 14, 5)),
+        ):
+            assert _mlx_available() is True
+
+    def test_blocks_python_315(self, _fake_mlx_core):
+        """Python 3.15 is not yet verified for MLX and must be blocked."""
+        from kb.embeddings import _mlx_available
+
+        with (
+            patch("kb.embeddings._is_apple_silicon", return_value=True),
+            patch.object(sys, "version_info", (3, 15, 0)),
+        ):
+            assert _mlx_available() is False
+
+
+class TestInstructionFormat:
+    """Qwen3-Embedding asymmetry: queries get an Instruct/Query template,
+    documents are embedded as raw text with no instruction (per the model card).
+    Both backends must agree so their vectors are interchangeable.
+    """
+
+    def test_format_query_matches_qwen3_template(self):
+        from kb.embeddings import QUERY_INSTRUCTION, _format_query
+
+        assert _format_query("hello world") == f"Instruct: {QUERY_INSTRUCTION}\nQuery: hello world"
+
+    def test_pytorch_documents_embed_without_instruction(self, tmp_path):
+        """Documents go through model.encode with an empty prompt (raw text)."""
+        from contextlib import contextmanager
+        from unittest.mock import MagicMock
+
+        import numpy as np
+
+        from kb.embeddings import _PyTorchBackend
+
+        backend = _PyTorchBackend(cache_dir=tmp_path, device="cpu")
+        mock_model = MagicMock()
+        mock_model.encode.return_value = np.random.randn(1, 1024).astype(np.float32)
+        backend._model = mock_model
+        backend._is_mps = False
+
+        @contextmanager
+        def mock_inference_mode():
+            yield
+
+        with patch("torch.inference_mode", mock_inference_mode):
+            backend.embed(["a document section"])
+
+        assert mock_model.encode.call_args.kwargs["prompt"] == ""
 
 
 # ---------------------------------------------------------------------------
@@ -342,13 +473,13 @@ class TestPyTorchLoadMocked:
         assert backend._is_mps is True
 
     def test_embed_query_with_mocked_model(self, tmp_path):
-        """embed_query() delegates to model.encode with QUERY_INSTRUCTION."""
+        """embed_query() encodes the Instruct/Query template as raw text (empty prompt)."""
         from contextlib import contextmanager
         from unittest.mock import MagicMock
 
         import numpy as np
 
-        from kb.embeddings import QUERY_INSTRUCTION, _PyTorchBackend
+        from kb.embeddings import _format_query, _PyTorchBackend
 
         backend = _PyTorchBackend(cache_dir=tmp_path, device="cpu")
         mock_model = MagicMock()
@@ -365,8 +496,9 @@ class TestPyTorchLoadMocked:
 
         assert result.shape == (1, 1024)
         mock_model.encode.assert_called_once()
-        call_kwargs = mock_model.encode.call_args
-        assert call_kwargs[1]["prompt"] == QUERY_INSTRUCTION
+        call = mock_model.encode.call_args
+        assert call.args[0] == [_format_query("test query")]
+        assert call.kwargs["prompt"] == ""
 
     def test_default_batch_size_cpu(self, tmp_path):
         """Default batch_size is 16 on CPU."""
@@ -608,12 +740,12 @@ class TestMLXBackendMocked:
         mock_release.assert_called()
 
     def test_mlx_embed_query(self, tmp_path):
-        """_MLXBackend.embed_query() delegates to _tokenize_and_run with instruction."""
+        """_MLXBackend.embed_query() tokenizes the Instruct/Query template."""
         from unittest.mock import MagicMock
 
         import numpy as np
 
-        from kb.embeddings import QUERY_INSTRUCTION, _MLXBackend
+        from kb.embeddings import _format_query, _MLXBackend
 
         backend = _MLXBackend.__new__(_MLXBackend)
         backend._model = MagicMock()
@@ -624,4 +756,36 @@ class TestMLXBackendMocked:
             result = backend.embed_query("test query")
 
         assert result.shape == (1, 1024)
-        mock_run.assert_called_once_with(["test query"], instruction=QUERY_INSTRUCTION)
+        mock_run.assert_called_once_with([_format_query("test query")])
+
+    def test_mlx_documents_tokenize_raw(self):
+        """Documents are tokenized as raw text — no Instruct/Query wrapping."""
+        from unittest.mock import MagicMock
+
+        import numpy as np
+
+        from kb.embeddings import _MLXBackend
+
+        backend = _MLXBackend.__new__(_MLXBackend)
+        mock_model = MagicMock()
+        mock_tokenizer = MagicMock()
+        backend._model = mock_model
+        backend._tokenizer = mock_tokenizer
+        mock_tokenizer.return_value = {
+            "input_ids": np.array([[1, 2, 3]], dtype=np.int64),
+            "attention_mask": np.array([[1, 1, 1]], dtype=np.int64),
+        }
+        mock_output = MagicMock()
+        fake_embeds = MagicMock()
+        fake_embeds.astype.return_value = MagicMock()
+        mock_output.text_embeds = fake_embeds
+        mock_model.return_value = mock_output
+
+        with (
+            patch("mlx.core.array", side_effect=lambda x: x),
+            patch("mlx.core.eval"),
+            patch("numpy.array", return_value=np.random.randn(1, 1024).astype(np.float32)),
+        ):
+            backend.embed(["a raw document section"], batch_size=64)
+
+        assert mock_tokenizer.call_args.args[0] == ["a raw document section"]

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -55,21 +55,22 @@ def test_embedder_query():
 
 @_skip_no_model
 @pytest.mark.slow
-def test_embedder_instruction_aware():
-    """Different instructions produce different embeddings."""
-    from kb.embeddings import INDEX_INSTRUCTION, QUERY_INSTRUCTION, Embedder
+def test_embedder_query_document_asymmetry():
+    """A query (Instruct/Query template) and a raw document embedding of the
+    same text are similar but not identical — Qwen3's asymmetric retrieval."""
+    from kb.embeddings import Embedder
 
     e = Embedder()
     text = "MFA implementation progress"
-    idx_emb = e.embed([text], instruction=INDEX_INSTRUCTION)[0]
-    query_emb = e.embed([text], instruction=QUERY_INSTRUCTION)[0]
+    doc_emb = e.embed([text])[0]  # document: raw text, no instruction
+    query_emb = e.embed_query(text)[0]  # query: Instruct/Query template
 
-    # They should be similar but not identical (different instructions)
-    similarity = np.dot(idx_emb, query_emb)
+    # Similar (same content) but not identical (query carries an instruction).
+    similarity = np.dot(doc_emb, query_emb)
     assert similarity > 0.5, (
-        f"Same text with different instructions should still be similar, got {similarity}"
+        f"Same text as query vs document should still be similar, got {similarity}"
     )
-    assert similarity < 1.0 - 1e-5, "Different instructions should produce different embeddings"
+    assert similarity < 1.0 - 1e-5, "Query template should differ from raw document embedding"
 
 
 def test_sqlite_schema():


### PR DESCRIPTION
## Problem

The `kbx index run` embedding step was ballooning to **~34 GB RSS** and getting `Killed: 9` (SIGKILL) by macOS memory pressure — surfaced as a runaway Python process from the 30-min `kb-sync` launchd job.

## Root causes (four, compounding)

1. **Stale MLX guard.** `embeddings.py` disabled the leak-free MLX backend on Python ≥3.14 (added when MLX had no 3.14 wheels). kbx therefore fell back to PyTorch+MPS, whose allocator leaks unboundedly (`pytorch#154329`) — and the code had set `PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.0`, removing the ceiling. MLX 0.31.2 now ships `cp314` wheels and runs correctly on 3.14 (verified GPU compute + Qwen3 embedding parity).
2. **Documents were instruction-prefixed.** The Qwen3 model card is explicit: *"no need to add instruction for retrieval documents"* — only queries get the `Instruct: …\nQuery: …` template. kbx was prepending an instruction to every document.
3. **The two backends formatted instructions differently**, producing incompatible vectors (cross-backend cosine **0.72**), so any backend switch silently corrupted retrieval.
4. **Real-model tests were silently skipping** — `conftest._model_cached()` checked the HF hub cache, but kbx stores the model under its own data dir. This is why the above hid for months.

## Changes

- Relax the MLX guard to block only the next *untested* CPython (3.15) → MLX is used on 3.14.
- Embed documents as raw text; wrap queries via a shared `_format_query` so **both backends format identically** (cross-backend cosine **0.72 → 0.999**, guarded by a new parity test).
- Fix `_model_cached()` to look in the kbx data dir → the embedding tests now actually run.

## Validation

- **1718 passed**, mypy clean, ruff clean. New parity + instruction tests; the previously-dead real-model tests now run via MLX.
- **Full reindex**: 5902 docs, 27467 chunks, 0 errors. **Peak RSS 2.1 GB** (was ~34 GB → **16× reduction**).
- **Retrieval** holds or improves — three previously-weak queries (staff-engineer interviews, AI adoption, career ladder) now return the right docs.

## ⚠️ Breaking change

Document and query embeddings changed; **existing indexes must be rebuilt** with `kbx index run --full`. The internal `embed()` `instruction` parameter was removed (documents are always raw now).
