### PR TITLE
docs: migrate kbx gotchas from personal memory; sync lockfile to 0.3.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,4 +195,6 @@ All write operations go through `KnowledgeBase` methods. CLI and MCP are thin wr
 - **`KB_DATA_DIR`** — env var overrides default `~/.config/kbx/`. Tests use this to isolate
 - **Incremental indexing** — skips unchanged files (by `content_hash`). Use `--full` to force
 - **LanceDB lazy import** — only loaded for vector ops. `--no-embed` skips entirely
-- **Slow tests** — `@pytest.mark.slow` on ML model tests; pre-commit skips them (`-m "not slow"`). Run all with `uv run pytest`
+- **LanceDB `list_tables()`** — returns a `ListTablesResponse`, NOT a list. Check membership via `"name" in db.list_tables().tables`. `db.table_names()` is deprecated.
+- **Entity list-value preservation** — the entity parser keeps YAML list values as Python lists (person + project parsers in `entities.py`); `types.py` metadata fields are `dict[str, Any]`. e.g. `task_keywords: [AI, agentic]` → `metadata['task_keywords'] == ['AI', 'agentic']`, not a stringified list.
+- **Slow tests** — `@pytest.mark.slow` on ML model tests; pre-commit skips them (`-m "not slow"`). Run all with `uv run pytest`. The model-cache check (`conftest._model_cached`) looks in `get_data_dir()/model` (where kbx stores it), so these tests run locally; they skip on CI where the model is absent.

--- a/uv.lock
+++ b/uv.lock
@@ -696,7 +696,7 @@ wheels = [
 
 [[package]]
 name = "kbx"
-version = "0.2.13"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Migrates three generic, machine-independent gotchas out of a personal memory file into the repo docs (where they belong on any machine): LanceDB `list_tables()` returns a `ListTablesResponse`; the entity parser preserves YAML list values; and the slow-test model-cache check resolves `get_data_dir()/model`. Also syncs `uv.lock` (kbx 0.2.13→0.3.0) — release-please bumped `pyproject.toml` but left the lock stale, which made the pre-commit `uv run` abort every commit. Docs/chore only — no code change, no release.