### PR TITLE
ci: only cut releases for shipping commit types

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,20 @@
       "release-type": "python",
       "package-name": "kbx",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true
+      "bump-patch-for-minor-pre-major": true,
+      "changelog-sections": [
+        { "type": "feat", "section": "Features" },
+        { "type": "fix", "section": "Bug Fixes" },
+        { "type": "perf", "section": "Performance Improvements" },
+        { "type": "deps", "section": "Dependencies" },
+        { "type": "docs", "section": "Documentation", "hidden": true },
+        { "type": "chore", "section": "Miscellaneous", "hidden": true },
+        { "type": "refactor", "section": "Code Refactoring", "hidden": true },
+        { "type": "test", "section": "Tests", "hidden": true },
+        { "type": "build", "section": "Build System", "hidden": true },
+        { "type": "ci", "section": "Continuous Integration", "hidden": true },
+        { "type": "style", "section": "Styles", "hidden": true }
+      ]
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"

--- a/uv.lock
+++ b/uv.lock
@@ -696,7 +696,7 @@ wheels = [
 
 [[package]]
 name = "kbx"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
release-please was cutting a PyPI release for a plain `docs:` commit (0.3.1) because v4.4.0's default `changelog-sections` leave `docs`/`chore`/etc non-hidden, and a non-hidden section counts as a releasable unit. This defines `changelog-sections` explicitly: **feat/fix/perf/deps** stay visible + releasable; **docs/chore/refactor/test/build/ci/style** are `hidden: true` and no longer trigger a release. Also resyncs `uv.lock` to 0.3.1. Self-test: this `ci:` PR should merge WITHOUT cutting a release.