### PR TITLE
fix: use fictional stand-ins for residual example names

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -160,8 +160,8 @@ kbx note delete "title"
 
 ```bash
 kbx correct "Quartz Indexer" --json             # scan: list all occurrences
-kbx correct "Quartz Indexer" "Coralogix"        # dry-run: preview replacements
-kbx correct "Quartz Indexer" "Coralogix" --apply  # execute replacements
+kbx correct "Quartz Indexer" "Datalux"        # dry-run: preview replacements
+kbx correct "Quartz Indexer" "Datalux" --apply  # execute replacements
 kbx correct "Bram" --word-boundary --json  # whole-word matches only
 ```
 

--- a/src/kb/cli.py
+++ b/src/kb/cli.py
@@ -331,11 +331,11 @@ kb note edit "person.md" --insert-under "## Open Items" --body "- [2026-05-25] i
   kb correct "Bram" --word-boundary --json               # scan: whole-word matches only
   kb correct "Quartz Indexer" --type transcript --json        # scan: filter by file type
   kb correct "Quartz Indexer" --scope "**/people/*" --json    # scan: filter by path glob
-  kb correct "Quartz Indexer" "Coralogix"                     # dry-run: preview replacements
-  kb correct "Quartz Indexer" "Coralogix" --apply             # apply: execute replacements
-  kb correct "Quartz Indexer" "Coralogix" --apply --json      # apply: structured result
+  kb correct "Quartz Indexer" "Datalux"                     # dry-run: preview replacements
+  kb correct "Quartz Indexer" "Datalux" --apply             # apply: execute replacements
+  kb correct "Quartz Indexer" "Datalux" --apply --json      # apply: structured result
   kb correct "Bram" "Bram" --word-boundary --scope "meetings/2026/02/17/*" --apply
-  kb correct "corelogix" "Coralogix" --ignore-case --apply  # case-insensitive replace
+  kb correct "datalux" "Datalux" --ignore-case --apply  # case-insensitive replace
 
   JSON scan output includes title, date, attendees, category per match — agent-ready
   for disambiguation decisions (e.g. which "Bram" is in this meeting).
@@ -1776,8 +1776,8 @@ def correct(
 
     \b
     Replace mode (with REPLACEMENT):
-      kb correct "Quartz Indexer" "Coralogix"             # dry-run preview
-      kb correct "Quartz Indexer" "Coralogix" --apply     # apply changes
+      kb correct "Quartz Indexer" "Datalux"             # dry-run preview
+      kb correct "Quartz Indexer" "Datalux" --apply     # apply changes
       kb correct "Bram" "Bram" --word-boundary --scope "meetings/2026/02/17/*" --apply
     """
     from kb.api import KnowledgeBase

--- a/src/kb/config.py
+++ b/src/kb/config.py
@@ -124,7 +124,7 @@ def find_entities(conn: sqlite3.Connection, name: str) -> list[sqlite3.Row]:
     if rows:
         return list(rows)
 
-    # Exact alias match — collect ALL matches (e.g. "Anders" is alias for both Erics)
+    # Exact alias match — collect ALL matches (e.g. "Anders" is an alias shared by two people)
     all_entities = conn.execute("SELECT * FROM entities").fetchall()
     alias_matches = []
     for e in all_entities:

--- a/src/kb/correct.py
+++ b/src/kb/correct.py
@@ -2,7 +2,7 @@
 
 Scans memory/ for literal string occurrences and applies replacements
 with atomic file writes. Designed for fixing STT garbles (e.g. Quartz Indexer →
-Coralogix) and entity name corrections (e.g. Bram → Bram).
+Datalux) and entity name corrections (e.g. Bram → Bram).
 """
 
 from __future__ import annotations

--- a/tests/test_correct.py
+++ b/tests/test_correct.py
@@ -53,7 +53,7 @@ def memory_tree(tmp_path: Path) -> Path:
     notes_dir.mkdir(parents=True)
     (notes_dir / "initiatives.md").write_text(
         "---\ntitle: Active Initiatives\ntags: [initiatives]\n---\n"
-        "# Initiatives\n- Coralogix refactor on track\n",
+        "# Initiatives\n- Datalux refactor on track\n",
         encoding="utf-8",
     )
 
@@ -61,7 +61,7 @@ def memory_tree(tmp_path: Path) -> Path:
     people_dir = memory / "people"
     people_dir.mkdir(parents=True)
     (people_dir / "soren-vance.md").write_text(
-        "---\nemail: eric@example.com\nrole: CEO\n---\n"
+        "---\nemail: soren@example.com\nrole: CEO\n---\n"
         "# Soren Vance\n\nDiscussed Quartz Indexer vendor evaluation.\n",
         encoding="utf-8",
     )
@@ -72,14 +72,14 @@ def memory_tree(tmp_path: Path) -> Path:
     (projects_dir / "observability-refactor.md").write_text(
         "---\nname: Observability Refactor\n---\n"
         "# Observability Refactor\n\n"
-        "Migrating from Quartz Indexer to Coralogix.\n"
-        "Granola garbles Coralogix as Quartz Indexer or Chorologix.\n",
+        "Migrating from Quartz Indexer to Datalux.\n"
+        "Granola garbles Datalux as Quartz Indexer or Chorologix.\n",
         encoding="utf-8",
     )
 
     # glossary
     (memory / "glossary.md").write_text(
-        "# Glossary\n\nCoralogix=Observability platform\n",
+        "# Glossary\n\nDatalux=Observability platform\n",
         encoding="utf-8",
     )
 
@@ -174,7 +174,7 @@ class TestApply:
     def test_apply_replaces_in_files(self, memory_tree: Path):
         """apply_corrections() modifies files on disk."""
         matches = scan(memory_tree, "Quartz Indexer")
-        result = apply_corrections(memory_tree, matches, "Coralogix")
+        result = apply_corrections(memory_tree, matches, "Datalux")
         assert result.files_changed > 0
         assert result.occurrences_replaced > 0
 
@@ -189,12 +189,12 @@ class TestApply:
         )
         content = transcript.read_text(encoding="utf-8")
         assert "Quartz Indexer" not in content
-        assert "Coralogix" in content
+        assert "Datalux" in content
 
     def test_apply_preserves_frontmatter(self, memory_tree: Path):
         """apply_corrections() doesn't corrupt YAML frontmatter."""
         matches = scan(memory_tree, "Quartz Indexer")
-        apply_corrections(memory_tree, matches, "Coralogix")
+        apply_corrections(memory_tree, matches, "Datalux")
 
         transcript = (
             memory_tree
@@ -214,7 +214,7 @@ class TestApply:
         apply_corrections(
             memory_tree,
             matches,
-            "Coralogix",
+            "Datalux",
             ignore_case=True,
         )
 
@@ -229,7 +229,7 @@ class TestApply:
         content = summary.read_text(encoding="utf-8")
         assert "Quartz Indexer" not in content
         assert "quartz indexer" not in content
-        assert content.count("Coralogix") >= 2
+        assert content.count("Datalux") >= 2
 
     def test_apply_word_boundary(self, memory_tree: Path):
         """word_boundary replacement only affects whole-word matches."""
@@ -258,20 +258,20 @@ class TestApply:
         """CorrectionResult has correct file and occurrence counts."""
         matches = scan(memory_tree, "Quartz Indexer")
         total_occurrences = sum(m.count for m in matches)
-        result = apply_corrections(memory_tree, matches, "Coralogix")
+        result = apply_corrections(memory_tree, matches, "Datalux")
         assert result.files_changed == len(matches)
         assert result.occurrences_replaced == total_occurrences
 
     def test_apply_no_matches_is_noop(self, memory_tree: Path):
         """apply_corrections() with empty matches changes nothing."""
-        result = apply_corrections(memory_tree, [], "Coralogix")
+        result = apply_corrections(memory_tree, [], "Datalux")
         assert result.files_changed == 0
         assert result.occurrences_replaced == 0
 
     def test_apply_logs_changed_files(self, memory_tree: Path):
         """CorrectionResult includes list of changed file paths."""
         matches = scan(memory_tree, "Quartz Indexer")
-        result = apply_corrections(memory_tree, matches, "Coralogix")
+        result = apply_corrections(memory_tree, matches, "Datalux")
         assert len(result.changed_paths) == result.files_changed
         assert all(isinstance(p, str) for p in result.changed_paths)
 
@@ -407,15 +407,15 @@ class TestCorrectCLI:
 
     def test_dry_run_json(self, cli_runner: CliRunner, memory_tree: Path):
         """kbx correct OLD NEW --json shows dry-run preview."""
-        result = self._invoke(cli_runner, memory_tree, ["Quartz Indexer", "Coralogix", "--json"])
+        result = self._invoke(cli_runner, memory_tree, ["Quartz Indexer", "Datalux", "--json"])
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert data["meta"]["action"] == "dry_run"
-        assert data["meta"]["replacement"] == "Coralogix"
+        assert data["meta"]["replacement"] == "Datalux"
 
     def test_dry_run_does_not_modify_files(self, cli_runner: CliRunner, memory_tree: Path):
         """Dry-run (no --apply) leaves files unchanged."""
-        self._invoke(cli_runner, memory_tree, ["Quartz Indexer", "Coralogix"])
+        self._invoke(cli_runner, memory_tree, ["Quartz Indexer", "Datalux"])
         transcript = (
             memory_tree
             / "meetings"
@@ -430,7 +430,7 @@ class TestCorrectCLI:
     def test_apply_modifies_files(self, cli_runner: CliRunner, memory_tree: Path):
         """kbx correct OLD NEW --apply actually replaces content."""
         result = self._invoke(
-            cli_runner, memory_tree, ["Quartz Indexer", "Coralogix", "--apply", "--json"]
+            cli_runner, memory_tree, ["Quartz Indexer", "Datalux", "--apply", "--json"]
         )
         assert result.exit_code == 0
         data = json.loads(result.output)
@@ -449,7 +449,7 @@ class TestCorrectCLI:
         )
         content = transcript.read_text(encoding="utf-8")
         assert "Quartz Indexer" not in content
-        assert "Coralogix" in content
+        assert "Datalux" in content
 
     def test_scope_flag(self, cli_runner: CliRunner, memory_tree: Path):
         """--scope limits scan to matching files."""
@@ -497,11 +497,11 @@ class TestAuditLog:
 
         log_path = tmp_path / "corrections.log"
         matches = scan(memory_tree, "Quartz Indexer")
-        apply_corrections(memory_tree, matches, "Coralogix", log_path=log_path)
+        apply_corrections(memory_tree, matches, "Datalux", log_path=log_path)
         assert log_path.exists()
         content = log_path.read_text(encoding="utf-8")
         assert "Quartz Indexer" in content
-        assert "Coralogix" in content
+        assert "Datalux" in content
 
     def test_audit_log_contains_timestamp(self, memory_tree: Path, tmp_path: Path):
         """Audit log entry includes an ISO timestamp."""
@@ -509,7 +509,7 @@ class TestAuditLog:
 
         log_path = tmp_path / "corrections.log"
         matches = scan(memory_tree, "Quartz Indexer")
-        apply_corrections(memory_tree, matches, "Coralogix", log_path=log_path)
+        apply_corrections(memory_tree, matches, "Datalux", log_path=log_path)
         content = log_path.read_text(encoding="utf-8")
         # ISO format: 2026-03-03T...
         assert "2026-" in content or "202" in content
@@ -520,7 +520,7 @@ class TestAuditLog:
 
         log_path = tmp_path / "corrections.log"
         matches = scan(memory_tree, "Quartz Indexer")
-        result = apply_corrections(memory_tree, matches, "Coralogix", log_path=log_path)
+        result = apply_corrections(memory_tree, matches, "Datalux", log_path=log_path)
         content = log_path.read_text(encoding="utf-8")
         assert str(result.files_changed) in content
         assert str(result.occurrences_replaced) in content
@@ -531,11 +531,11 @@ class TestAuditLog:
 
         log_path = tmp_path / "corrections.log"
         matches1 = scan(memory_tree, "Quartz Indexer")
-        apply_corrections(memory_tree, matches1, "Coralogix", log_path=log_path)
+        apply_corrections(memory_tree, matches1, "Datalux", log_path=log_path)
         matches2 = scan(memory_tree, "Bram", word_boundary=True)
         apply_corrections(memory_tree, matches2, "Bram", word_boundary=True, log_path=log_path)
         content = log_path.read_text(encoding="utf-8")
-        assert "Coralogix" in content
+        assert "Datalux" in content
         assert "Bram" in content
 
     def test_no_log_when_no_path(self, memory_tree: Path, tmp_path: Path):
@@ -543,7 +543,7 @@ class TestAuditLog:
         from kb.correct import apply_corrections, scan
 
         matches = scan(memory_tree, "Quartz Indexer")
-        apply_corrections(memory_tree, matches, "Coralogix")
+        apply_corrections(memory_tree, matches, "Datalux")
         # No file should be created in tmp_path
         log_files = list(tmp_path.glob("*.log"))
         # memory_tree is under tmp_path, so filter
@@ -647,7 +647,7 @@ class TestApplyJsonSchema:
         with patch("kb.cli._find_project_root", return_value=project_root):
             result = cli_runner.invoke(
                 cli,
-                ["correct", "Quartz Indexer", "Coralogix", "--apply", "--json"],
+                ["correct", "Quartz Indexer", "Datalux", "--apply", "--json"],
                 catch_exceptions=False,
             )
         assert result.exit_code == 0
@@ -665,7 +665,7 @@ class TestApplyJsonSchema:
         with patch("kb.cli._find_project_root", return_value=project_root):
             result = cli_runner.invoke(
                 cli,
-                ["correct", "Quartz Indexer", "Coralogix", "--apply", "--json"],
+                ["correct", "Quartz Indexer", "Datalux", "--apply", "--json"],
                 catch_exceptions=False,
             )
         data = json.loads(result.output)

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1729,7 +1729,7 @@ class TestMcpCorrect:
         _, root = mcp_db
         self._create_memory_files(root)
 
-        result = json.loads(handle_kb_correct(root, "Quartz Indexer", replacement="Coralogix"))
+        result = json.loads(handle_kb_correct(root, "Quartz Indexer", replacement="Datalux"))
         assert result["meta"]["action"] == "dry_run"
         assert result["meta"]["total_occurrences"] == 2
 
@@ -1746,13 +1746,13 @@ class TestMcpCorrect:
 
         with patch("kb.config.get_data_dir", return_value=root):
             result = json.loads(
-                handle_kb_correct(root, "Quartz Indexer", replacement="Coralogix", apply=True)
+                handle_kb_correct(root, "Quartz Indexer", replacement="Datalux", apply=True)
             )
         assert result["meta"]["action"] == "applied"
         assert result["meta"]["occurrences_replaced"] == 2
 
         content = (root / "memory" / "notes" / "test.md").read_text()
-        assert "Coralogix" in content
+        assert "Datalux" in content
         assert "Quartz Indexer" not in content
 
     def test_correct_no_matches(self, mcp_db):

--- a/tests/test_sync_granola.py
+++ b/tests/test_sync_granola.py
@@ -220,7 +220,7 @@ class TestAPIRequests:
         mock_response.json.return_value = {
             "people": [
                 {"name": "Wren Kasper", "email": "wren@example.com"},
-                {"name": "Soren Vance", "email": "thomas@example.com"},
+                {"name": "Soren Vance", "email": "soren@example.com"},
             ],
             "calendar_event": {
                 "title": "Weekly 1:1",
@@ -412,7 +412,7 @@ class TestBuildFrontmatter:
         metadata = {
             "people": [
                 {"name": "Wren Kasper", "email": "wren@example.com"},
-                {"name": "Soren Vance", "email": "thomas@example.com"},
+                {"name": "Soren Vance", "email": "soren@example.com"},
             ],
             "calendar_event": {
                 "title": "Weekly 1:1",
@@ -1280,7 +1280,7 @@ class TestEntityAutoCreation:
         conn = tmp_db.get_sqlite_conn()
         self._seed_entity(conn, "Soren Vance", aliases=["Soren"])
 
-        attendee = {"name": "Soren Vance", "email": "thomas@example.com"}
+        attendee = {"name": "Soren Vance", "email": "soren@example.com"}
         result = match_or_create_attendee(attendee, tmp_db, project_root=None)
 
         assert result is not None
@@ -1380,7 +1380,7 @@ attendees:
   - name: Wren Kasper
     email: wren@example.com
   - name: Soren Vance
-    email: thomas@example.com
+    email: soren@example.com
 calendar_event:
   title: Weekly 1:1
   organiser: wren@example.com
@@ -1439,7 +1439,7 @@ attendees:
   - name: Wren Kasper
     email: wren@example.com
   - name: Soren Vance
-    email: thomas@example.com
+    email: soren@example.com
 ---
 ## Discussion
 


### PR DESCRIPTION
Three minor naming residuals from the earlier history scrub remained in HEAD. This swaps them for fictional stand-ins:

- A source comment in `config.py` that referenced a non-fictional name.
- Test-fixture attendee emails carrying non-fictional local-parts.
- The `correct` command's example vendor name (help text, docstring, tests, docs) — now a fictional observability platform, consistent with the existing fictional example data.

No behavioural change; this is example/fixture/comment text only.

**Verification**
- `ruff check` + `ruff format --check` clean
- `mypy src/` clean
- pre-commit full non-slow suite green with ≥90% coverage
- `uv.lock` untouched (pypi.org only)

Typed `fix` so the cleaned source (the comment + help text ship in the package) reaches PyPI on the next release.
