### PR TITLE
chore: make the correct command's entity-name example coherent

### DIFF
--- a/src/kb/cli.py
+++ b/src/kb/cli.py
@@ -334,7 +334,7 @@ kb note edit "person.md" --insert-under "## Open Items" --body "- [2026-05-25] i
   kb correct "Quartz Indexer" "Datalux"                     # dry-run: preview replacements
   kb correct "Quartz Indexer" "Datalux" --apply             # apply: execute replacements
   kb correct "Quartz Indexer" "Datalux" --apply --json      # apply: structured result
-  kb correct "Bram" "Bram" --word-boundary --scope "meetings/2026/02/17/*" --apply
+  kb correct "Brahm" "Bram" --word-boundary --scope "meetings/2026/02/17/*" --apply
   kb correct "datalux" "Datalux" --ignore-case --apply  # case-insensitive replace
 
   JSON scan output includes title, date, attendees, category per match — agent-ready
@@ -1778,7 +1778,7 @@ def correct(
     Replace mode (with REPLACEMENT):
       kb correct "Quartz Indexer" "Datalux"             # dry-run preview
       kb correct "Quartz Indexer" "Datalux" --apply     # apply changes
-      kb correct "Bram" "Bram" --word-boundary --scope "meetings/2026/02/17/*" --apply
+      kb correct "Brahm" "Bram" --word-boundary --scope "meetings/2026/02/17/*" --apply
     """
     from kb.api import KnowledgeBase
 

--- a/src/kb/correct.py
+++ b/src/kb/correct.py
@@ -2,7 +2,7 @@
 
 Scans memory/ for literal string occurrences and applies replacements
 with atomic file writes. Designed for fixing STT garbles (e.g. Quartz Indexer →
-Datalux) and entity name corrections (e.g. Bram → Bram).
+Datalux) and entity name corrections (e.g. Brahm → Bram).
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Replaces the no-op `Bram -> Bram` example (source == target, a leftover from the earlier mechanical rename) with a coherent garble-to-canonical example (`Brahm -> Bram`). Help text + docstring only; no behavioural change. Typed `chore` so it does not cut its own release; it rides the next releasing commit. 420 tests pass; ruff + mypy clean; uv.lock untouched.