### PR TITLE
chore: add uv.lock public-index guard, pin index, ignore docs/plans

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,14 @@ jobs:
       - name: Test
         run: uv run pytest -x -q --cov --cov-fail-under=90 -m "not slow"
 
+  guards:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: uv.lock public-index guard
+        run: bash scripts/check-uv-lock-registry.sh
+
   release-please:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
@@ -92,7 +100,7 @@ jobs:
           gh pr merge "$PR_NUMBER" --auto --squash --repo "${{ github.repository }}"
 
   publish:
-    needs: [check, release-please]
+    needs: [check, release-please, guards]
     if: needs.release-please.outputs.release_created == 'true'
     runs-on: ubuntu-latest
     environment: pypi

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,11 @@ htmlcov/
 # Worktrees
 .worktrees/
 .mypy_cache/
+
+# Planning docs — may reference internal detail; keep out of the public repo
+docs/plans/
+
+# Local PII denylist + local config (never committed to the public repo)
+.pii-denylist
+.config.toml
+*.local.toml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,12 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
+      - id: uv-lock-registry
+        name: uv.lock public-index guard
+        entry: scripts/check-uv-lock-registry.sh
+        language: system
+        files: ^uv\.lock$
+        pass_filenames: false
       - id: ruff-check-pre-push
         name: ruff check (pre-push)
         entry: uv run ruff check .

--- a/scripts/check-uv-lock-registry.sh
+++ b/scripts/check-uv-lock-registry.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Guard: fail if uv.lock references a non-public package index.
+# Public repo => resolve only against pypi.org / files.pythonhosted.org.
+# Deliberately does NOT print the offending host (CI logs are public).
+set -euo pipefail
+lock="${1:-uv.lock}"
+[ -f "$lock" ] || exit 0
+bad="$(grep -oE 'https://[^"/]+' "$lock" | sort -u \
+        | grep -vxE 'https://(pypi\.org|files\.pythonhosted\.org)' || true)"
+if [ -n "$bad" ]; then
+  echo "ERROR: $lock references a non-public package index." >&2
+  echo "Public repos must resolve only against pypi.org / files.pythonhosted.org." >&2
+  echo "Regenerate (UV_INDEX must be UNSET — UV_DEFAULT_INDEX alone is not enough):" >&2
+  echo "  env -u UV_INDEX -u PIP_EXTRA_INDEX_URL UV_DEFAULT_INDEX=https://pypi.org/simple uv lock --refresh" >&2
+  exit 1
+fi

--- a/tests/test_correct.py
+++ b/tests/test_correct.py
@@ -37,9 +37,9 @@ def memory_tree(tmp_path: Path) -> Path:
     )
 
     # meeting with Bram/Bram ambiguity
-    arno_dir = memory / "meetings" / "2026" / "02" / "17"
-    arno_dir.mkdir(parents=True)
-    (arno_dir / "Monthly_Idris___Bramble.notion.transcript.md").write_text(
+    bram_dir = memory / "meetings" / "2026" / "02" / "17"
+    bram_dir.mkdir(parents=True)
+    (bram_dir / "Monthly_Idris___Bramble.notion.transcript.md").write_text(
         "---\ntitle: Monthly Idris & Bramble\ndate: '2026-02-17'\n"
         "attendees:\n- name: Idris Kalmar\n  email: idris@example.com\n"
         "- name: Bramble Holt\n  email: bram@example.com\n---\n"
@@ -127,9 +127,9 @@ class TestScan:
     def test_scan_word_boundary(self, memory_tree: Path):
         """word_boundary=True avoids substring matches."""
         matches = scan(memory_tree, "Bram", word_boundary=True)
-        arno_match = [m for m in matches if "Bram" in m.rel_path]
-        assert arno_match
-        assert arno_match[0].count == 2  # "Bram" appears twice as whole word
+        bram_match = [m for m in matches if "Bram" in m.rel_path]
+        assert bram_match
+        assert bram_match[0].count == 2  # "Bram" appears twice as whole word
 
     def test_scan_scope_glob(self, memory_tree: Path):
         """scope limits scan to matching files."""
@@ -242,7 +242,7 @@ class TestApply:
         )
         assert result.occurrences_replaced > 0
 
-        arno_file = (
+        bram_file = (
             memory_tree
             / "meetings"
             / "2026"
@@ -250,7 +250,7 @@ class TestApply:
             / "17"
             / "Monthly_Idris___Bramble.notion.transcript.md"
         )
-        content = arno_file.read_text(encoding="utf-8")
+        content = bram_file.read_text(encoding="utf-8")
         assert "Hey Bram" in content
         assert "Bram is one of the top" in content
 
@@ -318,9 +318,9 @@ class TestEnrichMatches:
         """enrich_matches() extracts attendees from meeting frontmatter."""
         matches = scan(memory_tree, "Bram", word_boundary=True)
         enriched = enrich_matches(memory_tree, matches)
-        arno = [e for e in enriched if "Bram" in e["rel_path"]]
-        assert arno
-        attendees = arno[0]["attendees"]
+        bram = [e for e in enriched if "Bram" in e["rel_path"]]
+        assert bram
+        attendees = bram[0]["attendees"]
         assert len(attendees) == 2
         names = [a["name"] for a in attendees]
         assert "Bramble Holt" in names

--- a/uv.toml
+++ b/uv.toml
@@ -1,0 +1,11 @@
+# Pin this public project to PyPI.
+#
+# This machine's global uv config (~/.config/uv/uv.toml) may point at a private
+# package mirror. Declaring the index here makes kbx resolve against PyPI by
+# default, so a routine `uv lock`/`uv sync` does not pollute uv.lock with
+# internal mirror URLs.
+#
+# Note: environment variables (UV_INDEX / UV_DEFAULT_INDEX) still override this
+# file, so the hard enforcement is scripts/check-uv-lock-registry.sh (run in
+# pre-commit and CI). This pin reduces accidents; the guard prevents leaks.
+index-url = "https://pypi.org/simple"


### PR DESCRIPTION
Independent infra guardrails from the PII-prevention plan. The shared **denylist scanner is intentionally not here** — its canonical form is owned at the dev-team level and is being resolved separately; this PR lands only the pieces that don't depend on it.

## What
- **uv.lock public-index guard** (`scripts/check-uv-lock-registry.sh`, the dev-team canonical) — fails if `uv.lock` references any non-PyPI host. Catches accidental internal-mirror pollution regardless of local uv config / env. **Does not print the offending host** (CI logs are public). Runs in pre-commit (when `uv.lock` is staged) and in a CI `guards` job; the `publish` job now `needs: guards`, so a polluted lockfile can't release.
- **`uv.toml`** — pins the default index to `pypi.org` so routine `uv lock`/`uv sync` doesn't pull a private mirror. (`uv lock --locked` passes; lockfile unchanged. Env still overrides — the guard is the hard enforcement.)
- **`.gitignore`** — `docs/plans/`, a local denylist file, and local config so none reach the public repo.
- **Residual cleanup** — renamed a leftover test variable to the fictional cast name. It was a scrub residual the earlier audit missed because macOS `git grep -E` treats `\b` as a literal backspace, not a word boundary (Linux CI honours it). Flagged for the canonical scanner: use Python `re`, not `git grep -E \b`.

## Out of scope (deliberately)
- The PII denylist scanner — pending resolution of the canonical implementation.
- `Bram → Bram` cosmetic fix — already merged (#16).

## Verification
- Guard tested both paths (clean lock passes silently; mirror URL fails without echoing the host).
- Portable Python re-audit of the tree: 0 hits.
- pre-commit full suite green; YAML parses for `ci.yml` + `.pre-commit-config.yaml`.

Type `chore` — repo tooling only, nothing package-facing, so no release.
