### PR TITLE
feat(search): per-term match detail in --explain (refs #3)

### DIFF
--- a/src/kb/explain.py
+++ b/src/kb/explain.py
@@ -52,6 +52,8 @@ def _fmt_result(idx: int, result: SearchResult) -> list[str]:
     lines.append(_explain_component_line(explain))
     lines.append(_explain_blend_line(explain))
     lines.append(_explain_signal_line(explain))
+    if explain.matched_terms:
+        lines.append(_explain_terms_line(explain))
     return lines
 
 
@@ -86,6 +88,20 @@ def _explain_signal_line(explain: SearchExplain) -> str:
         f"Entity boost: {boost}    "
         f"Final: {explain.final_score:.3f}"
     )
+
+
+def _explain_terms_line(explain: SearchExplain) -> str:
+    """Per-term match detail: which query terms matched and where (#3)."""
+    parts: list[str] = []
+    for tm in explain.matched_terms:
+        locs: list[str] = []
+        for loc in tm.locations:
+            if loc == "body" and tm.body_count:
+                locs.append(f"body:{tm.body_count}")
+            else:
+                locs.append(loc)
+        parts.append(f"{tm.term} ({', '.join(locs)})")
+    return "       Terms:   " + " · ".join(parts)
 
 
 def _fmt_meta(response: SearchResponse) -> list[str]:

--- a/src/kb/search.py
+++ b/src/kb/search.py
@@ -16,6 +16,7 @@ from kb.types import (
     SearchResponse,
     SearchResult,
     TermHit,
+    TermMatch,
     VectorNearMiss,
     ZeroResultDiagnostics,
 )
@@ -251,6 +252,35 @@ def _build_fts_query(query: str, extra_or_terms: list[str] | None = None) -> lis
             variants.append(or_extra)
 
     return variants
+
+
+def _compute_term_matches(query: str, title: str, content: str) -> list[TermMatch]:
+    """Which query terms appear in this result's title/body (issue #3 per-term detail).
+
+    Uses portable Python word-boundary matching (``re`` ``\\b``), not FTS5 offsets, so it
+    is engine-independent and works for both FTS- and vector-sourced results. Only terms
+    that match somewhere are returned; ``body_count`` is whole-word occurrences in the body.
+    """
+    title_l = title.lower()
+    content_l = content.lower()
+    out: list[TermMatch] = []
+    seen: set[str] = set()
+    for tok in re.findall(r"\w+", query):
+        key = tok.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        pat = re.compile(r"\b" + re.escape(key) + r"\b")
+        in_title = bool(pat.search(title_l))
+        body_count = len(pat.findall(content_l))
+        locations: list[str] = []
+        if in_title:
+            locations.append("title")
+        if body_count:
+            locations.append("body")
+        if locations:
+            out.append(TermMatch(term=tok, locations=locations, body_count=body_count))
+    return out
 
 
 def _resolve_doc_ids_for_path(db: Database, path_filter: str | None) -> set[int] | None:
@@ -1039,6 +1069,7 @@ def search(
                 fts_weight=fts_weight,
                 vector_weight=vector_weight,
                 recency=recency,
+                matched_terms=_compute_term_matches(query, info["title"], info["content"]),
             )
 
         results.append(

--- a/src/kb/types.py
+++ b/src/kb/types.py
@@ -114,6 +114,18 @@ class IndexResult(StrictMutable):
 # ---------------------------------------------------------------------------
 
 
+class TermMatch(StrictFrozen):
+    """Which query term matched where, within a single result (issue #3 per-term detail).
+
+    ``locations`` is a subset of ``["title", "body"]``; ``body_count`` is the number
+    of whole-word occurrences in the matched chunk body (0 when matched in the title only).
+    """
+
+    term: str
+    locations: list[str]
+    body_count: int
+
+
 class SearchExplain(StrictFrozen):
     """Per-result scoring breakdown — populated when ``explain=True``.
 
@@ -137,6 +149,7 @@ class SearchExplain(StrictFrozen):
     fts_weight: float
     vector_weight: float
     recency: float
+    matched_terms: list[TermMatch] = []  # query terms matched in this result (#3)
 
 
 class SearchResult(StrictFrozen):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -327,6 +327,20 @@ class TestSearchCommand:
             assert 0.0 <= ex["fts_score"] <= 1.0
             assert ex["final_score"] == pytest.approx(r["score"])
 
+    def test_search_explain_json_has_matched_terms(self, runner, cli_db):
+        """kb search --explain --json surfaces per-term match detail (#3)."""
+        _db, db_path = cli_db
+        result = invoke_cli(
+            runner,
+            ["search", "Rust", "--fast", "--json", "--explain"],
+            db_path,
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["results"], "expected at least one result for 'Rust'"
+        all_terms = [tm for r in data["results"] for tm in r["explain"]["matched_terms"]]
+        assert any(tm["term"].lower() == "rust" for tm in all_terms), all_terms
+
     def test_search_without_explain_omits_block(self, runner, cli_db):
         """Default search has no explain block — backward compat."""
         _db, db_path = cli_db

--- a/tests/test_explain_formatter.py
+++ b/tests/test_explain_formatter.py
@@ -8,6 +8,7 @@ from kb.types import (
     SearchResponse,
     SearchResult,
     TermHit,
+    TermMatch,
     VectorNearMiss,
     ZeroResultDiagnostics,
 )
@@ -97,6 +98,53 @@ class TestExplainFormatter:
         assert "memory/meetings/2026/02/foo.md" in out
         # Final score appears as a numeric formatted string
         assert "0.847" in out or "0.85" in out
+
+    def test_renders_matched_terms(self):
+        """Per-result explain surfaces which query terms matched and where (#3)."""
+        from kb.explain import format_explain_text
+
+        explain = SearchExplain(
+            fts_score=0.82,
+            vector_score=None,
+            fused_score=0.82,
+            recency_weight=None,
+            entity_boost_applied=False,
+            final_score=0.82,
+            source="fts_only",
+            fts_weight=1.0,
+            vector_weight=1.0,
+            recency=0.0,
+            matched_terms=[
+                TermMatch(term="deployment", locations=["title", "body"], body_count=3),
+                TermMatch(term="timeline", locations=["body"], body_count=2),
+            ],
+        )
+        result = _make_result(score=0.82, explain=explain)
+        out = format_explain_text(_make_response(results=[result]))
+        assert "deployment" in out
+        assert "timeline" in out
+        # body occurrence count is surfaced
+        assert "body:3" in out
+
+    def test_omits_terms_line_when_no_matches(self):
+        """No 'Terms:' line when matched_terms is empty (back-compat)."""
+        from kb.explain import format_explain_text
+
+        explain = SearchExplain(
+            fts_score=0.82,
+            vector_score=None,
+            fused_score=0.82,
+            recency_weight=None,
+            entity_boost_applied=False,
+            final_score=0.82,
+            source="fts_only",
+            fts_weight=1.0,
+            vector_weight=1.0,
+            recency=0.0,
+        )
+        result = _make_result(score=0.82, explain=explain)
+        out = format_explain_text(_make_response(results=[result]))
+        assert "Terms:" not in out
 
     def test_renders_component_scores(self):
         from kb.explain import format_explain_text

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1752,6 +1752,19 @@ class TestExplain:
             assert r.explain.fts_weight == 1.0
             assert r.explain.vector_weight == 1.0
 
+    def test_explain_populates_matched_terms(self, search_db):
+        """search(explain=True) records which query terms matched per result (#3)."""
+        results = search(search_db, None, "MFA", fast=True, explain=True)
+        assert results.results, "expected MFA query to return results"
+        all_terms = [
+            tm for r in results.results for tm in (r.explain.matched_terms if r.explain else [])
+        ]
+        assert any(tm.term.lower() == "mfa" for tm in all_terms), all_terms
+        for tm in all_terms:
+            assert tm.locations, "a matched term must record at least one location"
+            assert set(tm.locations) <= {"title", "body"}
+            assert tm.body_count >= 0
+
     def test_explain_meta_has_search_mode_fast(self, search_db):
         """fast=True reports search_mode='fast'."""
         results = search(search_db, None, "MFA", fast=True, explain=True)


### PR DESCRIPTION
First of issue #3's remaining phases: **per-term match detail** in `--explain`.

## What
`--explain` now reports, per result, which query terms matched and where:
- title and/or body location
- body occurrence count

Surfaced in:
- **human-readable formatter** — a `Terms:` line under each result's scoring breakdown (e.g. `deployment (title, body:3) · timeline (body:2)`)
- **`--explain --json` and MCP** — a `matched_terms` array on each result's `explain` block

Matching uses **portable Python word boundaries** (`re \b`), so it's engine-independent and works for both FTS- and vector-sourced results (no FTS5 offsets needed). This is the same portability point I flagged for the PII scanner — `git grep -E \b` is non-portable; Python `re` isn't.

## TDD
- formatter unit tests (renders matched terms; omits the line when none)
- integration test — `search(explain=True)` populates `matched_terms` from the real SQLite + LanceDB fixture
- E2E test — `kbx search --explain --json` includes `matched_terms`

## Out of scope (follow-ups for #3)
- `--verbose` (all FTS variants + per-variant hits, all chunks scored, timing breakdown)
- why-not mode (`--why-not PATH`)

## Verification
- 580 tests across the affected suites green; ruff + mypy clean; `uv.lock` untouched.

`feat` — user-facing explain enhancement; release-please will cut a release.
