### PR TITLE
feat(search): per-phase timing breakdown under --explain --verbose (refs #3)

### DIFF
--- a/src/kb/cli.py
+++ b/src/kb/cli.py
@@ -259,6 +259,7 @@ kb note edit "person.md" --insert-under "## Open Items" --body "- [2026-05-25] i
   kb search "query" --vector-weight 2.0 --json  # boost vector (semantic)
   kb search "query" --explain                  # readable per-result scoring breakdown (#68 P2)
   kb search "query" --explain --json           # raw structured explain fields (#68 P1)
+  kb search "query" --explain --verbose        # + per-phase timing breakdown (#3)
   kb search "query" --no-hotness --json        # disable hotness blend (#67)
   kb search "query" --no-hierarchy --json      # force flat (skip Pass 1 entity match, #69)
   kb search "query" --hierarchy-alpha 0.7 --json  # tune doc-vs-entity blend (#69)
@@ -461,6 +462,14 @@ def cli() -> None:
     ),
 )
 @click.option(
+    "--verbose",
+    is_flag=True,
+    help=(
+        "With --explain, add a per-phase timing breakdown (FTS / vector / merge) to the "
+        "meta header. No effect without --explain."
+    ),
+)
+@click.option(
     "--no-hotness",
     is_flag=True,
     help=(
@@ -508,6 +517,7 @@ def search(
     merge_chunks: bool,
     include_overview: bool,
     explain: bool,
+    verbose: bool,
     no_hotness: bool,
     no_hierarchy: bool,
     hierarchy_alpha: float,
@@ -561,6 +571,7 @@ def search(
         include_overview=include_overview,
         highlight=(fmt == "table"),
         explain=explain,
+        verbose=verbose,
         hotness=not no_hotness,
         hierarchy=not no_hierarchy,
         hierarchy_alpha=hierarchy_alpha,

--- a/src/kb/explain.py
+++ b/src/kb/explain.py
@@ -141,6 +141,10 @@ def _fmt_meta(response: SearchResponse) -> list[str]:
     if meta.expanded_terms:
         expansions = ", ".join(f"{k}→{v}" for k, v in meta.expanded_terms.items())
         lines.append(f"  glossary expansions: {expansions}")
+    if meta.timings:
+        t = meta.timings
+        vec = f"{t.vector_ms:.1f}ms" if t.vector_ms is not None else "—"
+        lines.append(f"  timings: fts {t.fts_ms:.1f}ms · vector {vec} · merge {t.merge_ms:.1f}ms")
     return lines
 
 

--- a/src/kb/search.py
+++ b/src/kb/search.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any
 
 from kb.entities import strip_wikilinks
 from kb.types import (
+    PhaseTimings,
     SearchExplain,
     SearchMeta,
     SearchResponse,
@@ -786,6 +787,7 @@ def search(
     include_overview: bool = False,
     highlight: bool = False,
     explain: bool = False,
+    verbose: bool = False,
     hotness: bool = True,
     hierarchy: bool = True,
     hierarchy_threshold: float = 0.5,
@@ -853,6 +855,7 @@ def search(
 
     # Step 1: FTS5 search
     hook.on_fts_start()
+    _t_fts0 = time.monotonic()
     fts_results = _fts_search(
         db,
         query,
@@ -860,24 +863,30 @@ def search(
         extra_or_terms=expansion_or_terms,
         doc_ids=path_doc_ids,
     )
+    _fts_ms = (time.monotonic() - _t_fts0) * 1000
     hook.on_fts_done(len(fts_results))
 
     # Step 2: Decide whether to do vector search
     vector_results: list[dict[str, Any]] = []
     used_fast_path = fast or _is_strong_signal(fts_results)
+    _vector_ms: float | None = None
 
     if not used_fast_path and embedder is not None:
         # Check if LanceDB has data
         table = db.get_lance_table()
         if table is not None:
             hook.on_vector_start()
+            _t_vec0 = time.monotonic()
             vector_results = _vector_search(
                 db, embedder, query, limit=limit * 5, doc_ids=path_doc_ids
             )
+            _vector_ms = (time.monotonic() - _t_vec0) * 1000
             hook.on_vector_done(len(vector_results))
         else:
             # FTS-only fallback — no vectors available
             print("Warning: No vector index found. Using FTS-only search.", file=sys.stderr)
+
+    _t_merge0 = time.monotonic()
 
     # Build per-chunk component score maps for explain output. Cheap when explain=False
     # because we only iterate the existing result lists.
@@ -1097,7 +1106,17 @@ def search(
     if sort_by == "date":
         results.sort(key=lambda r: r.date or "", reverse=True)
 
-    elapsed_ms = round((time.monotonic() - start_time) * 1000, 1)
+    _t_end = time.monotonic()
+    elapsed_ms = round((_t_end - start_time) * 1000, 1)
+    timings = (
+        PhaseTimings(
+            fts_ms=round(_fts_ms, 2),
+            vector_ms=round(_vector_ms, 2) if _vector_ms is not None else None,
+            merge_ms=round((_t_end - _t_merge0) * 1000, 2),
+        )
+        if (explain and verbose)
+        else None
+    )
 
     # Explain-mode meta (issue #68 Phase 1) — populated only when explain=True.
     if explain:
@@ -1147,6 +1166,7 @@ def search(
             pass1_entities=pass1_entities,
             hierarchy_alpha=hierarchy_alpha if hierarchy_active else None,
             zero_result_diagnostics=zero_diag,
+            timings=timings,
         )
     else:
         meta = SearchMeta(

--- a/src/kb/types.py
+++ b/src/kb/types.py
@@ -205,6 +205,14 @@ class ZeroResultDiagnostics(StrictFrozen):
     suggestions: list[str]
 
 
+class PhaseTimings(StrictFrozen):
+    """Per-phase search latency (ms) — populated when explain=True and verbose=True (#3)."""
+
+    fts_ms: float
+    vector_ms: float | None  # None on --fast (no vector phase)
+    merge_ms: float  # scoring + fusion + dedup + result building
+
+
 class SearchMeta(StrictFrozen):
     """Metadata about a search operation."""
 
@@ -229,6 +237,8 @@ class SearchMeta(StrictFrozen):
     hierarchy_alpha: float | None = None  # blend weight used in Pass 2 (#69)
     # Zero-result diagnostics (#3) — populated only when explain=True AND 0 results.
     zero_result_diagnostics: ZeroResultDiagnostics | None = None
+    # Per-phase timing breakdown (#3) — populated only when explain=True AND verbose=True.
+    timings: PhaseTimings | None = None
 
 
 class SearchResponse(StrictFrozen):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -341,6 +341,22 @@ class TestSearchCommand:
         all_terms = [tm for r in data["results"] for tm in r["explain"]["matched_terms"]]
         assert any(tm["term"].lower() == "rust" for tm in all_terms), all_terms
 
+    def test_search_explain_verbose_json_has_timings(self, runner, cli_db):
+        """kb search --explain --verbose --json surfaces a per-phase timing breakdown (#3)."""
+        _db, db_path = cli_db
+        result = invoke_cli(
+            runner,
+            ["search", "Rust", "--fast", "--json", "--explain", "--verbose"],
+            db_path,
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        t = data["meta"]["timings"]
+        assert t is not None, "verbose explain should attach phase timings"
+        assert t["fts_ms"] >= 0.0
+        assert t["merge_ms"] >= 0.0
+        assert t["vector_ms"] is None  # --fast: no vector phase
+
     def test_search_without_explain_omits_block(self, runner, cli_db):
         """Default search has no explain block — backward compat."""
         _db, db_path = cli_db

--- a/tests/test_explain_formatter.py
+++ b/tests/test_explain_formatter.py
@@ -64,6 +64,29 @@ class TestExplainFormatter:
         out = format_explain_text(_make_response())
         assert isinstance(out, str)
 
+    def test_renders_timing_breakdown(self):
+        """--verbose surfaces a per-phase timing breakdown in the meta header (#3)."""
+        from kb.explain import format_explain_text
+        from kb.types import PhaseTimings
+
+        resp = _make_response(
+            results=[_make_result()],
+            meta_overrides={"timings": PhaseTimings(fts_ms=1.2, vector_ms=8.5, merge_ms=2.4)},
+        )
+        out = format_explain_text(resp)
+        assert "fts" in out.lower()
+        assert "1.2" in out  # fts
+        assert "8.5" in out  # vector
+        assert "merge" in out.lower()
+        assert "2.4" in out  # merge
+
+    def test_omits_timing_breakdown_when_absent(self):
+        """No timings line without --verbose (back-compat)."""
+        from kb.explain import format_explain_text
+
+        out = format_explain_text(_make_response(results=[_make_result()]))
+        assert "timings:" not in out
+
     def test_empty_response_mentions_no_results(self):
         from kb.explain import format_explain_text
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1765,6 +1765,21 @@ class TestExplain:
             assert set(tm.locations) <= {"title", "body"}
             assert tm.body_count >= 0
 
+    def test_explain_verbose_populates_timings(self, search_db):
+        """search(explain=True, verbose=True) records a per-phase timing breakdown (#3)."""
+        results = search(search_db, None, "MFA", fast=True, explain=True, verbose=True)
+        t = results.meta.timings
+        assert t is not None, "verbose explain should attach phase timings"
+        assert t.fts_ms >= 0.0
+        assert t.merge_ms >= 0.0
+        # fast=True → no vector phase
+        assert t.vector_ms is None
+
+    def test_explain_without_verbose_has_no_timings(self, search_db):
+        """meta.timings stays None without verbose (back-compat)."""
+        results = search(search_db, None, "MFA", fast=True, explain=True)
+        assert results.meta.timings is None
+
     def test_explain_meta_has_search_mode_fast(self, search_db):
         """fast=True reports search_mode='fast'."""
         results = search(search_db, None, "MFA", fast=True, explain=True)


### PR DESCRIPTION
Second of issue #3's remaining phases: **per-phase timing breakdown** under `--explain --verbose`.

## What
`--explain --verbose` now adds a latency breakdown to the meta header:
```
  timings: fts 1.2ms · vector 8.5ms · merge 2.4ms
```
- **Human-readable**: a `timings:` line in the meta block.
- **JSON / MCP**: `meta.timings` = `{fts_ms, vector_ms, merge_ms}` (`vector_ms` is `null` on `--fast`).
- Phases: FTS query · vector search · merge (scoring + fusion + dedup + result build).

Timers are only built when **both** `--explain` and `--verbose` are set, so the normal path and plain `--explain` are byte-for-byte unchanged.

## TDD
- integration: `search(explain=True, verbose=True)` populates `meta.timings`; stays `None` without verbose
- formatter: renders the timings line; omits it when absent
- E2E: `kbx search --explain --verbose --json` exposes `meta.timings`

## Out of scope (follow-ups for #3)
- the heavier `--verbose` detail (all chunks scored per doc + dedup decisions)
- why-not mode (`--why-not PATH`) — design approved, next PR

## Verification
- 585 tests across the affected suites green; ruff + mypy clean; `uv.lock` untouched; `_AGENT_PLAYBOOK` updated.

`feat` — user-facing; release-please will cut a release.
