### PR TITLE
feat(search): --why-not PATH explains why a document didn't surface (refs #3)

### DIFF
--- a/src/kb/cli.py
+++ b/src/kb/cli.py
@@ -260,6 +260,7 @@ kb note edit "person.md" --insert-under "## Open Items" --body "- [2026-05-25] i
   kb search "query" --explain                  # readable per-result scoring breakdown (#68 P2)
   kb search "query" --explain --json           # raw structured explain fields (#68 P1)
   kb search "query" --explain --verbose        # + per-phase timing breakdown (#3)
+  kb search "query" --why-not PATH             # why a specific doc didn't surface (#3)
   kb search "query" --no-hotness --json        # disable hotness blend (#67)
   kb search "query" --no-hierarchy --json      # force flat (skip Pass 1 entity match, #69)
   kb search "query" --hierarchy-alpha 0.7 --json  # tune doc-vs-entity blend (#69)
@@ -470,6 +471,16 @@ def cli() -> None:
     ),
 )
 @click.option(
+    "--why-not",
+    "why_not",
+    default=None,
+    metavar="PATH",
+    help=(
+        "Explain why a specific document did or didn't surface for the query "
+        "(ranked / below-cutoff / no-match / not-indexed / filtered). Implies --explain output."
+    ),
+)
+@click.option(
     "--no-hotness",
     is_flag=True,
     help=(
@@ -518,6 +529,7 @@ def search(
     include_overview: bool,
     explain: bool,
     verbose: bool,
+    why_not: str | None,
     no_hotness: bool,
     no_hierarchy: bool,
     hierarchy_alpha: float,
@@ -549,6 +561,8 @@ def search(
             fast = True
 
     db = _get_db()
+    if why_not:
+        explain = True  # why-not renders through the explain formatter
     results = do_search(
         db,
         embedder,
@@ -572,6 +586,7 @@ def search(
         highlight=(fmt == "table"),
         explain=explain,
         verbose=verbose,
+        why_not=why_not,
         hotness=not no_hotness,
         hierarchy=not no_hierarchy,
         hierarchy_alpha=hierarchy_alpha,

--- a/src/kb/explain.py
+++ b/src/kb/explain.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
         SearchExplain,
         SearchResponse,
         SearchResult,
+        WhyNotDiagnostics,
         ZeroResultDiagnostics,
     )
 
@@ -148,6 +149,18 @@ def _fmt_meta(response: SearchResponse) -> list[str]:
     return lines
 
 
+def _fmt_why_not(wn: WhyNotDiagnostics) -> list[str]:
+    """Render why-not diagnostics for a targeted document (#3 why-not mode)."""
+    lines = ["", f'Why-not "{wn.path}": {wn.status}']
+    if wn.rank is not None:
+        rank_part = f"  rank #{wn.rank}"
+        if wn.cutoff is not None:
+            rank_part += f" (cutoff: top {wn.cutoff})"
+        lines.append(rank_part)
+    lines.append(f"  {wn.detail}")
+    return lines
+
+
 def _fmt_zero_result_diagnostics(diag: ZeroResultDiagnostics) -> list[str]:
     """Render zero-result diagnostics: per-term FTS coverage, near-misses, suggestions (#3)."""
     lines: list[str] = ["No results — diagnostics:"]
@@ -196,6 +209,8 @@ def format_explain_text(response: SearchResponse) -> str:
     """
     lines: list[str] = []
     lines.extend(_fmt_meta(response))
+    if response.meta.why_not is not None:
+        lines.extend(_fmt_why_not(response.meta.why_not))
 
     if not response.results:
         lines.append("")

--- a/src/kb/search.py
+++ b/src/kb/search.py
@@ -19,6 +19,7 @@ from kb.types import (
     TermHit,
     TermMatch,
     VectorNearMiss,
+    WhyNotDiagnostics,
     ZeroResultDiagnostics,
 )
 
@@ -312,6 +313,70 @@ def _resolve_doc_ids_for_path(db: Database, path_filter: str | None) -> set[int]
         (like_pattern,),
     ).fetchall()
     return {row["id"] for row in rows}
+
+
+def _build_why_not_diagnostics(
+    db: Database,
+    target: str,
+    ranked_doc_ids: list[int],
+    enriched: dict[int, dict[str, Any]],
+    path_doc_ids: set[int] | None,
+    limit: int,
+) -> WhyNotDiagnostics:
+    """Explain why ``target`` did or didn't surface for the query (issue #3 why-not mode).
+
+    ``ranked_doc_ids`` is the doc-level candidate ranking (best chunk first), so a
+    target's score rank is its position there. Status is one of: not_indexed, ranked,
+    below_cutoff, no_match, filtered_path.
+    """
+    target_docs = _resolve_doc_ids_for_path(db, target) or set()
+    if not target_docs:
+        return WhyNotDiagnostics(
+            path=target,
+            status="not_indexed",
+            detail="This path is not in the index. Run `kbx index run` to index it.",
+        )
+
+    rank: int | None = None
+    for i, did in enumerate(ranked_doc_ids):
+        if did in target_docs:
+            rank = i + 1
+            break
+
+    if rank is not None:
+        if rank <= limit:
+            return WhyNotDiagnostics(
+                path=target,
+                status="ranked",
+                rank=rank,
+                detail=f"Indexed and returned at rank {rank} (within the top {limit}).",
+            )
+        return WhyNotDiagnostics(
+            path=target,
+            status="below_cutoff",
+            rank=rank,
+            cutoff=limit,
+            detail=(
+                f"Indexed and scored, but ranked #{rank} — below the top {limit} cutoff. "
+                f"Raise --limit to at least {rank} to surface it."
+            ),
+        )
+
+    if path_doc_ids is not None and target_docs.isdisjoint(path_doc_ids):
+        return WhyNotDiagnostics(
+            path=target,
+            status="filtered_path",
+            detail="Excluded by the --path filter — the document is outside the filtered scope.",
+        )
+
+    return WhyNotDiagnostics(
+        path=target,
+        status="no_match",
+        detail=(
+            "Indexed, but no chunk matched the query (no FTS or vector hit). "
+            "Try broader terms, or raise --vector-weight to lean on semantic matching."
+        ),
+    )
 
 
 def _pass1_entity_search(
@@ -788,6 +853,7 @@ def search(
     highlight: bool = False,
     explain: bool = False,
     verbose: bool = False,
+    why_not: str | None = None,
     hotness: bool = True,
     hierarchy: bool = True,
     hierarchy_threshold: float = 0.5,
@@ -1009,6 +1075,17 @@ def search(
     # Sort by score descending (initial ordering)
     scored.sort(key=lambda x: x[1], reverse=True)
 
+    # Why-not (#3): doc-level ranking by best chunk score, captured pre-truncation so a
+    # target document's rank can be reported even when it fell below the limit.
+    why_not_ranked_docs: list[int] = []
+    if why_not is not None:
+        _wn_seen: set[int] = set()
+        for _cid, _ in scored:
+            _did = enriched[_cid]["document_id"]
+            if _did not in _wn_seen:
+                _wn_seen.add(_did)
+                why_not_ranked_docs.append(_did)
+
     # Deduplicate: keep only the best chunk per document, count matching chunks
     doc_chunk_counts: dict[int, int] = {}
     doc_chunk_ids: dict[int, list[int]] = {}  # doc_id -> all matching chunk_ids
@@ -1118,6 +1195,12 @@ def search(
         else None
     )
 
+    why_not_diag = (
+        _build_why_not_diagnostics(db, why_not, why_not_ranked_docs, enriched, path_doc_ids, limit)
+        if why_not is not None
+        else None
+    )
+
     # Explain-mode meta (issue #68 Phase 1) — populated only when explain=True.
     if explain:
         fts_ids = set(fts_score_map.keys())
@@ -1167,6 +1250,7 @@ def search(
             hierarchy_alpha=hierarchy_alpha if hierarchy_active else None,
             zero_result_diagnostics=zero_diag,
             timings=timings,
+            why_not=why_not_diag,
         )
     else:
         meta = SearchMeta(
@@ -1176,6 +1260,7 @@ def search(
             sort_by=sort_by,
             execution_ms=elapsed_ms,
             expanded_terms=expanded_terms,
+            why_not=why_not_diag,
         )
 
     return SearchResponse(results=results, meta=meta)

--- a/src/kb/types.py
+++ b/src/kb/types.py
@@ -213,6 +213,17 @@ class PhaseTimings(StrictFrozen):
     merge_ms: float  # scoring + fusion + dedup + result building
 
 
+class WhyNotDiagnostics(StrictFrozen):
+    """Why a specific document did/didn't surface for a query (#3 why-not mode)."""
+
+    path: str
+    # "not_indexed" | "ranked" | "below_cutoff" | "no_match" | "filtered_path"
+    status: str
+    detail: str
+    rank: int | None = None  # 1-based score rank (ranked / below_cutoff)
+    cutoff: int | None = None  # the limit, when below_cutoff
+
+
 class SearchMeta(StrictFrozen):
     """Metadata about a search operation."""
 
@@ -239,6 +250,8 @@ class SearchMeta(StrictFrozen):
     zero_result_diagnostics: ZeroResultDiagnostics | None = None
     # Per-phase timing breakdown (#3) — populated only when explain=True AND verbose=True.
     timings: PhaseTimings | None = None
+    # Why-not diagnostics (#3) — populated only when why_not=PATH is requested.
+    why_not: WhyNotDiagnostics | None = None
 
 
 class SearchResponse(StrictFrozen):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -357,6 +357,21 @@ class TestSearchCommand:
         assert t["merge_ms"] >= 0.0
         assert t["vector_ms"] is None  # --fast: no vector phase
 
+    def test_search_why_not_json(self, runner, cli_db):
+        """kb search --why-not PATH attaches why-not diagnostics (#3)."""
+        _db, db_path = cli_db
+        result = invoke_cli(
+            runner,
+            ["search", "Rust", "--fast", "--json", "--why-not", "memory/nope/missing.md"],
+            db_path,
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        wn = data["meta"]["why_not"]
+        assert wn is not None, "why-not diagnostics should be attached"
+        assert wn["status"] == "not_indexed"
+        assert wn["path"] == "memory/nope/missing.md"
+
     def test_search_without_explain_omits_block(self, runner, cli_db):
         """Default search has no explain block — backward compat."""
         _db, db_path = cli_db

--- a/tests/test_explain_formatter.py
+++ b/tests/test_explain_formatter.py
@@ -64,6 +64,28 @@ class TestExplainFormatter:
         out = format_explain_text(_make_response())
         assert isinstance(out, str)
 
+    def test_renders_why_not(self):
+        """why-not diagnostics render a prominent section (#3)."""
+        from kb.explain import format_explain_text
+        from kb.types import WhyNotDiagnostics
+
+        resp = _make_response(
+            results=[_make_result()],
+            meta_overrides={
+                "why_not": WhyNotDiagnostics(
+                    path="doc4.md",
+                    status="below_cutoff",
+                    rank=2,
+                    cutoff=1,
+                    detail="Indexed and scored, but ranked #2 — below the top 1 cutoff.",
+                )
+            },
+        )
+        out = format_explain_text(resp)
+        assert "doc4.md" in out
+        assert "below_cutoff" in out
+        assert "ranked #2" in out
+
     def test_renders_timing_breakdown(self):
         """--verbose surfaces a per-phase timing breakdown in the meta header (#3)."""
         from kb.explain import format_explain_text

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -2202,3 +2202,56 @@ class TestZeroResultDiagnostics:
         # enriched with the real title/path from the fixture document
         assert near[0].title == "Helix Refactor Status"
         assert near[0].path == "doc2.md"
+
+
+class TestWhyNot:
+    """search(why_not=PATH) explains why a specific document did/didn't surface (#3)."""
+
+    def test_why_not_off_by_default(self, search_db):
+        r = search(search_db, None, "MFA", fast=True)
+        assert r.meta.why_not is None
+
+    def test_why_not_not_indexed(self, search_db):
+        r = search(search_db, None, "MFA", fast=True, why_not="memory/nope/missing.md")
+        wn = r.meta.why_not
+        assert wn is not None
+        assert wn.status == "not_indexed"
+        assert wn.path == "memory/nope/missing.md"
+
+    def test_why_not_ranked(self, search_db):
+        r = search(search_db, None, "MFA", fast=True, why_not="doc1.md")
+        wn = r.meta.why_not
+        assert wn is not None
+        assert wn.status == "ranked"
+        assert wn.rank == 1
+
+    def test_why_not_no_match(self, search_db):
+        # doc4 (Atlas Pipeline) has no "MFA" content → indexed but not a candidate
+        r = search(search_db, None, "MFA", fast=True, why_not="doc4.md")
+        wn = r.meta.why_not
+        assert wn is not None
+        assert wn.status == "no_match"
+
+    def test_why_not_below_cutoff(self, search_db):
+        # "refactor" matches doc2 (title+body) and doc4 (body only); doc2 outranks doc4,
+        # so with limit=1 doc4 is a scored candidate that falls below the cutoff.
+        r = search(search_db, None, "refactor", fast=True, limit=1, why_not="doc4.md")
+        wn = r.meta.why_not
+        assert wn is not None
+        assert wn.status == "below_cutoff"
+        assert wn.rank == 2
+        assert wn.cutoff == 1
+
+    def test_why_not_filtered_path(self, search_db):
+        # restrict the search to doc2; ask why doc4 (also a "refactor" match) didn't appear
+        r = search(
+            search_db,
+            None,
+            "refactor",
+            fast=True,
+            path_filter="doc2.md",
+            why_not="doc4.md",
+        )
+        wn = r.meta.why_not
+        assert wn is not None
+        assert wn.status == "filtered_path"


### PR DESCRIPTION
Third of issue #3's remaining phases: **why-not mode** (`--why-not PATH`).

## What
`kbx search "query" --why-not PATH` reports why a specific document did or didn't surface, classifying the target into one of:
- **ranked** — returned, with its position
- **below_cutoff** — scored candidate, but outside the top-N (suggests raising `--limit`)
- **no_match** — indexed, but no FTS/vector hit for the query
- **not_indexed** — path isn't in the index
- **filtered_path** — excluded by an active `--path` filter

Surfaced in the explain formatter (a `Why-not "PATH": status` section) and as `meta.why_not` in the JSON/MCP payload.

Design note: it's a **distinct flag**, not an overload of `--path` (which is a scope filter) — and it implies `--explain` output so the diagnostic renders.

## TDD
- integration: all five status branches via the real fixture DB (`TestWhyNot`, 6 tests)
- formatter: renders the why-not section
- E2E: `kbx search --why-not <missing> --json` → `meta.why_not.status == "not_indexed"`

## Out of scope (remaining #3 follow-up)
- the heavier `--verbose` detail: all chunks scored per doc + dedup decisions (the timing breakdown shipped in 0.3.4).

## Verification
- 593 tests across the affected suites green; ruff + mypy clean; `uv.lock` untouched; `_AGENT_PLAYBOOK` updated.

`feat` — user-facing; release-please will cut a release. With this, issue #3's three named remaining phases (per-term, verbose, why-not) are all shipped.
