### PR TITLE
feat(writes): auto-commit `correct --apply` when enabled (refs #1)

### DIFF
--- a/src/kb/autocommit.py
+++ b/src/kb/autocommit.py
@@ -1,0 +1,110 @@
+"""Auto-commit memory writes to git (issue #1, CLI-only).
+
+Off by default. When ``WritesConfig.auto_commit`` is set and the project is a git
+repo, ``maybe_auto_commit`` makes a single commit per CLI write command, scoped to
+the ``memory/`` directory. CLI-only by construction: only ``cli.py`` calls this —
+MCP writes never do, so the unattended sync pipeline stays out of git history.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from kb.user_config import WritesConfig
+
+
+class _SafeDict(dict[str, object]):
+    """format_map mapping that renders unknown placeholders as empty strings."""
+
+    def __missing__(self, key: str) -> str:
+        return ""
+
+
+def _is_git_repo(root: Path) -> bool:
+    try:
+        subprocess.run(  # nosec B607 — git is a standard system utility; fixed args, no shell
+            ["git", "-C", str(root), "rev-parse", "--git-dir"],
+            capture_output=True,
+            check=True,
+        )
+        return True
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return False
+
+
+def _format_message(fmt: str, operation: str, target: str, file_count: int) -> str:
+    mapping = _SafeDict(
+        operation=operation,
+        target=target,
+        file_count=file_count,
+        timestamp=datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        command="",
+    )
+    return fmt.format_map(mapping).strip()
+
+
+def maybe_auto_commit(
+    project_root: Path,
+    *,
+    operation: str,
+    target: str,
+    config: WritesConfig,
+    no_commit: bool,
+    file_count: int = 1,
+) -> str | None:
+    """Commit ``memory/`` changes after a CLI write, when enabled. Returns the SHA or None.
+
+    No-ops (returns None) when auto-commit is off, ``--no-commit`` is set, the project
+    is not a git repo, or nothing under ``memory/`` is staged. Never raises on git
+    trouble — a failed auto-commit must not fail the user's write.
+    """
+    if not config.auto_commit or no_commit:
+        return None
+    if not _is_git_repo(project_root):
+        return None
+
+    root = str(project_root)
+    memory = str(project_root / "memory")
+    try:
+        # Stage only memory/ — never sweep unrelated working-tree edits into the commit.
+        subprocess.run(  # nosec B607
+            ["git", "-C", root, "add", "--", memory], capture_output=True, check=True
+        )
+        # Nothing staged under memory/? (returncode 0 == no diff) → nothing to commit.
+        if (
+            subprocess.run(  # nosec B607
+                ["git", "-C", root, "diff", "--cached", "--quiet", "--", memory]
+            ).returncode
+            == 0
+        ):
+            return None
+        message = _format_message(config.auto_commit_message_format, operation, target, file_count)
+        subprocess.run(  # nosec B607
+            [
+                "git",
+                "-C",
+                root,
+                "commit",
+                "--author",
+                config.auto_commit_author,
+                "-m",
+                message,
+                "--",
+                memory,
+            ],
+            capture_output=True,
+            check=True,
+        )
+        return subprocess.run(  # nosec B607
+            ["git", "-C", root, "rev-parse", "HEAD"],
+            capture_output=True,
+            check=True,
+            text=True,
+        ).stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None

--- a/src/kb/cli.py
+++ b/src/kb/cli.py
@@ -1779,6 +1779,11 @@ def ingest(paths: tuple[str, ...], dry_run: bool, skip_organise: bool) -> None:
 )
 @click.option("--word-boundary", is_flag=True, help="Only match whole words.")
 @click.option("--ignore-case", is_flag=True, help="Case-insensitive matching.")
+@click.option(
+    "--no-commit",
+    is_flag=True,
+    help="Skip the git auto-commit even when [writes].auto_commit is enabled (#1).",
+)
 @output_options
 def correct(
     term: str,
@@ -1788,6 +1793,7 @@ def correct(
     file_type: str | None,
     word_boundary: bool,
     ignore_case: bool,
+    no_commit: bool,
     fmt: str,
     fields: list[str] | None,
     jq_expr: str | None,
@@ -1805,6 +1811,10 @@ def correct(
       kb correct "Quartz Indexer" "Datalux"             # dry-run preview
       kb correct "Quartz Indexer" "Datalux" --apply     # apply changes
       kb correct "Brahm" "Bram" --word-boundary --scope "meetings/2026/02/17/*" --apply
+
+    \b
+    With [writes].auto_commit enabled in kbx.toml, --apply makes one git commit of the
+    change (audit trail + git revert). Pass --no-commit to skip it. (#1)
     """
     from kb.api import KnowledgeBase
 
@@ -1826,6 +1836,24 @@ def correct(
         raise SystemExit(1) from None
     finally:
         kb.close()
+
+    # Auto-commit applied changes (issue #1, CLI-only). Dry-run/scan writes nothing.
+    if apply_flag and result.get("results"):
+        from kb.autocommit import maybe_auto_commit
+        from kb.user_config import KbxConfig, find_config, load_config
+
+        _config_path = find_config()
+        _cfg = load_config(_config_path) if _config_path else KbxConfig()
+        _sha = maybe_auto_commit(
+            project_root,
+            operation="correct",
+            target=f'"{term}" → "{replacement}"',
+            config=_cfg.writes,
+            no_commit=no_commit,
+            file_count=int(result["meta"].get("files") or len(result["results"])),
+        )
+        if _sha:
+            click.echo(f"  auto-committed {_sha[:8]}", err=True)
 
     meta = result["meta"]
     action = meta.get("action", "scan")

--- a/src/kb/user_config.py
+++ b/src/kb/user_config.py
@@ -58,6 +58,18 @@ class SyncConfig(BaseModel):
     granola: GranolaSyncConfig = GranolaSyncConfig()
 
 
+class WritesConfig(BaseModel):
+    """Auto-commit configuration for CLI write operations (issue #1).
+
+    Off by default. When enabled and the memory directory is inside a git repo,
+    each CLI command that mutates memory files makes a single git commit.
+    """
+
+    auto_commit: bool = False
+    auto_commit_message_format: str = "kbx: {operation} {target}"
+    auto_commit_author: str = "kbx <kbx@localhost>"
+
+
 class KbxConfig(BaseModel):
     """Top-level kbx configuration."""
 
@@ -65,6 +77,7 @@ class KbxConfig(BaseModel):
     data: DataConfig = DataConfig()
     user: UserConfig = UserConfig()
     sync: SyncConfig = SyncConfig()
+    writes: WritesConfig = WritesConfig()
 
 
 def find_config(cwd: Path | None = None) -> Path | None:

--- a/tests/test_autocommit.py
+++ b/tests/test_autocommit.py
@@ -1,0 +1,136 @@
+"""Tests for auto-commit on CLI writes (issue #1)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from kb.user_config import WritesConfig
+
+
+def _git(args: list[str], cwd: Path) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def _init_repo(root: Path) -> None:
+    _git(["init"], root)
+    _git(["config", "user.email", "t@example.com"], root)
+    _git(["config", "user.name", "Test"], root)
+    mem = root / "memory" / "notes"
+    mem.mkdir(parents=True)
+    (mem / "n.md").write_text("initial\n", encoding="utf-8")
+    _git(["add", "-A"], root)
+    _git(["commit", "-m", "initial"], root)
+
+
+def _head_subject(root: Path) -> str:
+    out = subprocess.run(
+        ["git", "log", "-1", "--pretty=%s"], cwd=root, capture_output=True, text=True
+    )
+    return out.stdout.strip()
+
+
+def _commit_count(root: Path) -> int:
+    out = subprocess.run(
+        ["git", "rev-list", "--count", "HEAD"], cwd=root, capture_output=True, text=True
+    )
+    return int(out.stdout.strip())
+
+
+class TestMaybeAutoCommit:
+    def test_commits_when_enabled(self, tmp_path: Path):
+        from kb.autocommit import maybe_auto_commit
+
+        _init_repo(tmp_path)
+        (tmp_path / "memory" / "notes" / "n.md").write_text("changed\n", encoding="utf-8")
+        sha = maybe_auto_commit(
+            tmp_path,
+            operation="add-fact",
+            target="Person A",
+            config=WritesConfig(auto_commit=True),
+            no_commit=False,
+        )
+        assert sha is not None
+        assert _commit_count(tmp_path) == 2
+        assert _head_subject(tmp_path) == "kbx: add-fact Person A"
+
+    def test_no_commit_when_disabled(self, tmp_path: Path):
+        from kb.autocommit import maybe_auto_commit
+
+        _init_repo(tmp_path)
+        (tmp_path / "memory" / "notes" / "n.md").write_text("changed\n", encoding="utf-8")
+        sha = maybe_auto_commit(
+            tmp_path,
+            operation="add-fact",
+            target="Person A",
+            config=WritesConfig(auto_commit=False),
+            no_commit=False,
+        )
+        assert sha is None
+        assert _commit_count(tmp_path) == 1
+
+    def test_no_commit_when_no_commit_flag(self, tmp_path: Path):
+        from kb.autocommit import maybe_auto_commit
+
+        _init_repo(tmp_path)
+        (tmp_path / "memory" / "notes" / "n.md").write_text("changed\n", encoding="utf-8")
+        sha = maybe_auto_commit(
+            tmp_path,
+            operation="add-fact",
+            target="P",
+            config=WritesConfig(auto_commit=True),
+            no_commit=True,
+        )
+        assert sha is None
+        assert _commit_count(tmp_path) == 1
+
+    def test_no_commit_when_not_a_git_repo(self, tmp_path: Path):
+        from kb.autocommit import maybe_auto_commit
+
+        (tmp_path / "memory").mkdir()
+        sha = maybe_auto_commit(
+            tmp_path,
+            operation="add-fact",
+            target="P",
+            config=WritesConfig(auto_commit=True),
+            no_commit=False,
+        )
+        assert sha is None  # graceful — no exception when not a repo
+
+    def test_returns_none_when_no_changes(self, tmp_path: Path):
+        from kb.autocommit import maybe_auto_commit
+
+        _init_repo(tmp_path)
+        sha = maybe_auto_commit(
+            tmp_path,
+            operation="add-fact",
+            target="P",
+            config=WritesConfig(auto_commit=True),
+            no_commit=False,
+        )
+        assert sha is None
+        assert _commit_count(tmp_path) == 1
+
+    def test_only_stages_memory_dir(self, tmp_path: Path):
+        """A dirty file outside memory/ must not be swept into the auto-commit."""
+        from kb.autocommit import maybe_auto_commit
+
+        _init_repo(tmp_path)
+        (tmp_path / "memory" / "notes" / "n.md").write_text("changed\n", encoding="utf-8")
+        (tmp_path / "unrelated.txt").write_text("dirty\n", encoding="utf-8")
+        sha = maybe_auto_commit(
+            tmp_path,
+            operation="add-fact",
+            target="P",
+            config=WritesConfig(auto_commit=True),
+            no_commit=False,
+        )
+        assert sha is not None
+        # unrelated.txt stays untracked/unstaged after the commit
+        status = subprocess.run(
+            ["git", "status", "--porcelain", "unrelated.txt"],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+        ).stdout
+        assert "unrelated.txt" in status  # still dirty, not committed

--- a/tests/test_correct.py
+++ b/tests/test_correct.py
@@ -688,3 +688,53 @@ class TestNfcNormalization:
             assert m.rel_path == unicodedata.normalize("NFC", m.rel_path), (
                 f"rel_path not NFC-normalized: {m.rel_path!r}"
             )
+
+
+class TestCorrectAutoCommit:
+    """`kbx correct` wires auto-commit on --apply only (issue #1).
+
+    The real git behaviour is covered by tests/test_autocommit.py; here we assert
+    the CLI control flow — that the helper is invoked with the right args on --apply,
+    not on a dry-run, and that --no-commit is passed through.
+    """
+
+    def _invoke(self, runner: CliRunner, memory_tree: Path, args: list[str]):
+        project_root = memory_tree.parent
+        with patch("kb.cli._find_project_root", return_value=project_root):
+            return runner.invoke(cli, ["correct", *args], catch_exceptions=False)
+
+    def test_apply_invokes_auto_commit(self, cli_runner: CliRunner, memory_tree: Path, monkeypatch):
+        from unittest.mock import MagicMock
+
+        mock = MagicMock(return_value="abc1234")
+        monkeypatch.setattr("kb.autocommit.maybe_auto_commit", mock)
+        result = self._invoke(cli_runner, memory_tree, ["Quartz Indexer", "Datalux", "--apply"])
+        assert result.exit_code == 0, result.output
+        mock.assert_called_once()
+        _, kwargs = mock.call_args
+        assert kwargs["operation"] == "correct"
+        assert kwargs["no_commit"] is False
+
+    def test_dry_run_does_not_invoke_auto_commit(
+        self, cli_runner: CliRunner, memory_tree: Path, monkeypatch
+    ):
+        from unittest.mock import MagicMock
+
+        mock = MagicMock(return_value=None)
+        monkeypatch.setattr("kb.autocommit.maybe_auto_commit", mock)
+        self._invoke(cli_runner, memory_tree, ["Quartz Indexer", "Datalux"])
+        mock.assert_not_called()
+
+    def test_no_commit_flag_passed_through(
+        self, cli_runner: CliRunner, memory_tree: Path, monkeypatch
+    ):
+        from unittest.mock import MagicMock
+
+        mock = MagicMock(return_value=None)
+        monkeypatch.setattr("kb.autocommit.maybe_auto_commit", mock)
+        self._invoke(
+            cli_runner, memory_tree, ["Quartz Indexer", "Datalux", "--apply", "--no-commit"]
+        )
+        mock.assert_called_once()
+        _, kwargs = mock.call_args
+        assert kwargs["no_commit"] is True


### PR DESCRIPTION
Issue #1, auto-commit slice (v1). Opt-in git audit trail for CLI writes, starting with the issue's motivating case.

## What
With `[writes].auto_commit = true` in kbx.toml, `kbx correct --apply` records its change as a **single git commit** (`kbx: correct "old" → "new"`) — so a bulk correction across many files has an audit trail and a clean `git revert`, instead of being an irreversible fire-and-forget write.

- **CLI-only** (per team-lead): MCP writes and the unattended 30-min sync pipeline stay out of git history — only deliberate human CLI writes commit.
- **Default off.** Opt in via kbx.toml.
- **Scoped to `memory/`** — never sweeps unrelated working-tree edits into the commit.
- **`--no-commit`** escape hatch on the command.
- Per-command granularity (one commit per command, even when `correct --apply` touches many files).

## Design
- `WritesConfig` (`[writes]`: `auto_commit`, `auto_commit_message_format`, `auto_commit_author`).
- Reusable `kb.autocommit.maybe_auto_commit(...)` — git-detect, stage `memory/`, commit, return SHA; no-ops (returns None) when disabled / `--no-commit` / not a git repo / nothing staged; never raises (a failed auto-commit must not fail the write).
- Wired into `correct` (the highest-risk write). **Remaining write commands** (memory / person / project / note / glossary) wire to the same helper in a fast follow-up; **COW batch atomicity** is the next slice.

## TDD
- `tests/test_autocommit.py` — 6 tests against a **real temp git repo**: commits when enabled; no-ops when disabled / `--no-commit` / not-a-repo / no-changes; message format; only stages `memory/` (unrelated edits untouched).
- `tests/test_correct.py::TestCorrectAutoCommit` — 3 wiring tests: invoked on `--apply`, not on dry-run, `--no-commit` passed through.

## Verification
- 256 affected-suite tests green; ruff + format + mypy + bandit clean (`# nosec B607` on the `git` subprocess calls, matching the existing sync-module pattern).

`feat` — user-facing (config + `--no-commit`); release-please will cut a release.
