### PR TITLE
feat(entities): persist false-positive entity↔document unlink (#35)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,11 +159,12 @@ All write operations go through `KnowledgeBase` methods. CLI and MCP are thin wr
 
 ## MCP Server
 
-- **31 tools** with full MCP tool annotations (`readOnlyHint`, `destructiveHint`, `idempotentHint`)
+- **33 tools** with full MCP tool annotations (`readOnlyHint`, `destructiveHint`, `idempotentHint`)
 - **Handler pattern**: thin `handle_*` wrappers that create `KnowledgeBase._from_existing(db, project_root)` and delegate to API methods. MCP tool functions call `get_db()`/`find_project_root()` then pass to handlers.
 - **Entity CRUD tools**: `kb_person_create`, `kb_person_edit`, `kb_project_create`, `kb_project_edit` — metadata via named params + `meta` string (semicolon-delimited `key=value` pairs).
 - **Fact tools**: `kb_memory_add` (fact or note), `kb_memory_edit_fact(entity, fact_seq, ...)`, `kb_memory_delete_fact(entity, fact_seq)` — entity-scoped seq IDs.
 - **Entity find**: `kb_person_find` / `kb_project_find` return facts with `seq` IDs + `mcp_breadcrumbs` (tool + params for agents) alongside CLI breadcrumbs.
+- **Entity link suppression**: `kb_entity_unlink(entity, document)` / `kb_entity_relink(entity, document)` — suppress/restore a false-positive entity↔document match. Persists in `memory/.kbx/entity-suppressions.json` (survives reindex + Granola sync); see `docs/entities.md` §Suppressions.
 - **`kb_usage`**: Structured JSON stats (docs, entities, facts, pinned, date_range, tool_count).
 - **Error shape**: `{"error": str, "suggestion": str | null}` — all tools
 - **List shape**: `{"results": [...], "meta": {"total": N, "limit": N}}` — all list tools. `total` is the true count, not capped by limit.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -35,7 +35,9 @@ kbx
 │   ├── edit <name>          # Edit a project's metadata
 │   └── delete <name>        # Delete a project
 ├── entity
-│   └── stale                # Entities not mentioned recently
+│   ├── stale                # Entities not mentioned recently
+│   ├── unlink <name> <doc>  # Suppress a false-positive entity↔doc match
+│   └── relink <name> <doc>  # Undo a suppression
 ├── memory
 │   ├── add <text>           # Create a note or record a fact
 │   ├── list                 # List facts

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -111,9 +111,34 @@ Five-tier matching against document metadata and content:
 - Single names 4+ chars (e.g. "Anders", "Wren") are matched in both content and title
 - File-stem aliases with hyphens (e.g. "dave-martin") are excluded from content matching
 
+## Suppressions (manual unlink/relink)
+
+Automatic linking is heuristic, so it occasionally produces a false positive (a bare
+first name that matched the wrong person, a title substring that isn't really about the
+entity). Because `entity_mentions` are **re-derived on every index** (and Granola sync
+regenerates meeting files), a correction can't live in the DB row or in document
+frontmatter — it would be wiped on the next sync. Instead, suppressions live in a sidecar:
+
+```
+memory/.kbx/entity-suppressions.json
+{ "<doc rel-path>": ["<entity name>", ...] }
+```
+
+- **`kbx entity unlink "Name" <doc>`** records the suppression and deletes the live
+  mention now. `<doc>` resolves by path, title, or content hash.
+- **`kbx entity relink "Name" <doc>`** removes the suppression; the link is re-derived on
+  the next index of that document.
+- The indexer loads the sidecar (`kb.suppressions.load_suppressions`), maps suppressed
+  entity names→ids per document, and passes `suppressed_ids` to `find_entity_mentions`,
+  which skips those entities for that document across **all** matching tiers.
+- Entity names (not ids) are the key, so suppressions survive the id churn of a full
+  re-index. Matching is case-insensitive.
+
+MCP equivalents: `kb_entity_unlink` / `kb_entity_relink` (both idempotent).
+
 ## Idempotency
 
-`seed_entities()` clears and re-seeds on every `index_all()` call. Entity IDs may change between full re-indexes; entity_mentions are also cleared.
+`seed_entities()` clears and re-seeds on every `index_all()` call. Entity IDs may change between full re-indexes; entity_mentions are also cleared and re-derived — except links suppressed via `kbx entity unlink`, which persist through the sidecar store (keyed by entity *name*, so id churn doesn't matter).
 
 ## Testing
 

--- a/src/kb/api.py
+++ b/src/kb/api.py
@@ -1723,6 +1723,52 @@ class KnowledgeBase:
     # Corrections
     # ------------------------------------------------------------------
 
+    def unlink_entity(self, entity: str, document: str) -> dict[str, object]:
+        """Suppress a false-positive entity↔document link and drop the live mention (#35).
+
+        The suppression persists in a sidecar (``memory/.kbx/entity-suppressions.json``) so
+        it survives reindex and Granola sync; the live ``entity_mentions`` row is removed now.
+        Raises ValueError if the entity or document can't be resolved.
+        """
+        from kb.crud import find_document_by_target
+        from kb.suppressions import add_suppression
+
+        ent = self.get_entity(entity)
+        if ent is None:
+            raise ValueError(f"Entity not found: {entity}")
+        conn = self._get_conn()
+        doc = find_document_by_target(conn, document)
+        if doc is None:
+            raise ValueError(f"Document not found: {document}")
+
+        add_suppression(self._project_root, doc["path"], ent.name)
+        conn.execute(
+            "DELETE FROM entity_mentions WHERE entity_id = ? AND document_id = ?",
+            (ent.id, doc["id"]),
+        )
+        conn.commit()
+        return {"entity": ent.name, "document": doc["path"], "unlinked": True}
+
+    def relink_entity(self, entity: str, document: str) -> dict[str, object]:
+        """Remove a suppression so the matcher may re-link the entity to the document (#35).
+
+        Re-derivation happens on the next index of that document. Raises ValueError if the
+        entity or document can't be resolved.
+        """
+        from kb.crud import find_document_by_target
+        from kb.suppressions import remove_suppression
+
+        ent = self.get_entity(entity)
+        if ent is None:
+            raise ValueError(f"Entity not found: {entity}")
+        conn = self._get_conn()
+        doc = find_document_by_target(conn, document)
+        if doc is None:
+            raise ValueError(f"Document not found: {document}")
+
+        removed = remove_suppression(self._project_root, doc["path"], ent.name)
+        return {"entity": ent.name, "document": doc["path"], "relinked": removed}
+
     def correct_term(
         self,
         term: str,

--- a/src/kb/cli.py
+++ b/src/kb/cli.py
@@ -292,6 +292,8 @@ kb note edit "person.md" --insert-under "## Open Items" --body "- [2026-05-25] i
   kb entity stale --json               # entities not updated/mentioned in 30+ days
   kb entity stale --days 60 --json     # custom threshold
   kb entity stale --type person --json # filter by type
+  kb entity unlink "Name" DOC          # suppress a false-positive entity↔doc match
+  kb entity relink "Name" DOC          # undo a suppression (re-derives on next index)
 
 ## Glossary contract
   kb glossary add "TERM" "expansion"
@@ -1509,8 +1511,69 @@ def project_list(fmt: str, fields: list[str] | None, jq_expr: str | None) -> Non
 
 @cli.group()
 def entity() -> None:
-    """Entity commands — stale detection."""
+    """Entity commands — stale detection, unlink/relink false-positive matches."""
     pass
+
+
+@entity.command("unlink")
+@click.argument("entity_name")
+@click.argument("document")
+@output_options
+@_commit_option
+def entity_unlink(
+    entity_name: str,
+    document: str,
+    no_commit: bool,
+    fmt: str,
+    fields: list[str] | None,
+    jq_expr: str | None,
+) -> None:
+    """Suppress a false-positive entity↔document link.
+
+    Drops the live mention now and records the suppression in a sidecar
+    (memory/.kbx/entity-suppressions.json) so it survives reindex and sync.
+    ENTITY_NAME is the entity name/alias; DOCUMENT is a path, title, or hash.
+    """
+    from kb.api import KnowledgeBase
+
+    kb = KnowledgeBase(data_dir=_get_data_dir(), project_root=_find_project_root())
+    try:
+        result = kb.unlink_entity(entity_name, document)
+    except ValueError as e:
+        click.echo(str(e), err=True)
+        raise SystemExit(1) from None
+    _autocommit_after_write("unlink-entity", f"{entity_name} ✕ {document}", no_commit=no_commit)
+    kb_output(result, fmt=fmt, fields=fields, jq_expr=jq_expr)
+
+
+@entity.command("relink")
+@click.argument("entity_name")
+@click.argument("document")
+@output_options
+@_commit_option
+def entity_relink(
+    entity_name: str,
+    document: str,
+    no_commit: bool,
+    fmt: str,
+    fields: list[str] | None,
+    jq_expr: str | None,
+) -> None:
+    """Remove a suppression so the entity may re-link to the document.
+
+    The link is re-derived on the next index of that document.
+    ENTITY_NAME is the entity name/alias; DOCUMENT is a path, title, or hash.
+    """
+    from kb.api import KnowledgeBase
+
+    kb = KnowledgeBase(data_dir=_get_data_dir(), project_root=_find_project_root())
+    try:
+        result = kb.relink_entity(entity_name, document)
+    except ValueError as e:
+        click.echo(str(e), err=True)
+        raise SystemExit(1) from None
+    _autocommit_after_write("relink-entity", f"{entity_name} ↔ {document}", no_commit=no_commit)
+    kb_output(result, fmt=fmt, fields=fields, jq_expr=jq_expr)
 
 
 @entity.command("stale")

--- a/src/kb/entities.py
+++ b/src/kb/entities.py
@@ -669,6 +669,7 @@ def find_entity_mentions(
     entities: list[Entity],
     *,
     cached_patterns: list[tuple[re.Pattern[str], Entity]] | None = None,
+    suppressed_ids: set[int] | None = None,
 ) -> list[EntityMention]:
     """Find entity mentions in a document's metadata and content.
 
@@ -686,8 +687,11 @@ def find_entity_mentions(
     """
     mentions: list[EntityMention] = []
     seen: set[tuple[int, str]] = set()
+    _suppressed = suppressed_ids or set()
 
     def _add(entity_id: int, mention_type: str) -> None:
+        if entity_id in _suppressed:
+            return  # entity↔document link suppressed for this document (#35)
         key = (entity_id, mention_type)
         if key not in seen:
             seen.add(key)

--- a/src/kb/indexer.py
+++ b/src/kb/indexer.py
@@ -19,6 +19,7 @@ from kb.entities import (
 )
 from kb.sources.meetings import walk_meetings
 from kb.sources.memory import walk_memory
+from kb.suppressions import load_suppressions
 from kb.sync.granola import match_or_create_attendee
 from kb.types import IndexResult as IndexResult
 
@@ -178,6 +179,15 @@ def index_all(
     entities = load_entities(db)
     entity_patterns = build_entity_patterns(entities)
 
+    # Entity-link suppressions (#35): per-document "do not link entity X here", kept in a
+    # sidecar so they survive reindex + Granola sync. Resolve names → entity ids once.
+    suppressions = load_suppressions(project_root)
+    entity_name_to_id: dict[str, int] = {}
+    for _e in entities:
+        entity_name_to_id[_e.name.lower()] = _e.id
+        for _a in _e.aliases:
+            entity_name_to_id.setdefault(_a.lower(), _e.id)
+
     # Get existing hashes for incremental mode
     existing_hashes = _get_existing_hashes(db)
 
@@ -308,8 +318,17 @@ def index_all(
 
             # Entity linking (before summary so we can include entity info in summary prefix)
             section_content = " ".join(chunk_texts)
+            _doc_suppressed = suppressions.get(doc.path, set())
+            _suppressed_ids = {
+                entity_name_to_id[n] for n in _doc_suppressed if n in entity_name_to_id
+            }
             mentions = find_entity_mentions(
-                doc.title, doc.tags, section_content, entities, cached_patterns=entity_patterns
+                doc.title,
+                doc.tags,
+                section_content,
+                entities,
+                cached_patterns=entity_patterns,
+                suppressed_ids=_suppressed_ids,
             )
             entity_id_set = {m.entity_id for m in mentions}
             result.entities_linked += len(mentions)

--- a/src/kb/mcp_server.py
+++ b/src/kb/mcp_server.py
@@ -382,6 +382,44 @@ def handle_kb_entity_stale(
         return json.dumps({"error": str(e), "results": []})
 
 
+def handle_kb_entity_unlink(db: Database, project_root: Path, entity: str, document: str) -> str:
+    """Suppress a false-positive entity↔document link. Delegates to KnowledgeBase."""
+    try:
+        from kb.api import KnowledgeBase
+
+        kb = KnowledgeBase._from_existing(db=db, project_root=project_root)
+        try:
+            result = kb.unlink_entity(entity, document)
+            return json.dumps(result, default=str, ensure_ascii=False)
+        except ValueError as e:
+            return json.dumps({"error": str(e)})
+        finally:
+            kb.close()
+    except Exception as e:
+        print(f"kb_entity_unlink error: {e}", file=sys.stderr)
+        traceback.print_exc(file=sys.stderr)
+        return json.dumps({"error": str(e)})
+
+
+def handle_kb_entity_relink(db: Database, project_root: Path, entity: str, document: str) -> str:
+    """Remove an entity↔document suppression so the link may be re-derived. Delegates to KB."""
+    try:
+        from kb.api import KnowledgeBase
+
+        kb = KnowledgeBase._from_existing(db=db, project_root=project_root)
+        try:
+            result = kb.relink_entity(entity, document)
+            return json.dumps(result, default=str, ensure_ascii=False)
+        except ValueError as e:
+            return json.dumps({"error": str(e)})
+        finally:
+            kb.close()
+    except Exception as e:
+        print(f"kb_entity_relink error: {e}", file=sys.stderr)
+        traceback.print_exc(file=sys.stderr)
+        return json.dumps({"error": str(e)})
+
+
 def handle_kb_project_find(db: Database, name: str) -> str:
     """Look up a project profile. Returns JSON string."""
     try:
@@ -1214,6 +1252,30 @@ def kb_entity_stale(days: int = 30, entity_type: str | None = None) -> str:
     days = max(1, days)
     db = get_db()
     return handle_kb_entity_stale(db, days=days, entity_type=entity_type)
+
+
+@mcp.tool(annotations=_MUTATING_IDEMPOTENT)
+def kb_entity_unlink(entity: str, document: str) -> str:
+    """Suppress a false-positive link between an entity and a document.
+    Use when search wrongly attributes a document to a person/project (e.g. a bare
+    first name matched the wrong person). Drops the live mention now and persists the
+    suppression so it survives reindex and Granola sync. Reversible with kb_entity_relink.
+    entity: entity name or alias.
+    document: path, title, or content hash."""
+    db = get_db()
+    project_root = find_project_root()
+    return handle_kb_entity_unlink(db, project_root, entity, document)
+
+
+@mcp.tool(annotations=_MUTATING_IDEMPOTENT)
+def kb_entity_relink(entity: str, document: str) -> str:
+    """Remove a previously-recorded entity↔document suppression.
+    The link is re-derived on the next index of that document. Use to undo a kb_entity_unlink.
+    entity: entity name or alias.
+    document: path, title, or content hash."""
+    db = get_db()
+    project_root = find_project_root()
+    return handle_kb_entity_relink(db, project_root, entity, document)
 
 
 @mcp.tool(annotations=_READ_ONLY)

--- a/src/kb/suppressions.py
+++ b/src/kb/suppressions.py
@@ -1,0 +1,80 @@
+"""Persistent entity↔document link suppressions (kbx #35 / #36).
+
+Entity↔document links are re-derived on every reindex, and Granola sync regenerates
+meeting files — so a suppression ("this entity is *not* in this document") cannot live
+in document frontmatter. It lives in a sidecar file at
+``memory/.kbx/entity-suppressions.json``, loaded by the indexer and honoured when
+deriving entity mentions.
+
+Shape: ``{"<doc rel-path>": ["<entity name>", ...], ...}``; entity names match
+case-insensitively. JSON (not TOML) because it is machine-written and JSON has a stdlib
+writer.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+_REL = Path("memory") / ".kbx" / "entity-suppressions.json"
+
+
+def _store_path(project_root: Path) -> Path:
+    return project_root / _REL
+
+
+def _load_raw(project_root: Path) -> dict[str, list[str]]:
+    p = _store_path(project_root)
+    if not p.is_file():
+        return {}
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    out: dict[str, list[str]] = {}
+    for doc, ents in data.items():
+        if isinstance(doc, str) and isinstance(ents, list):
+            out[doc] = [e for e in ents if isinstance(e, str)]
+    return out
+
+
+def _save_raw(project_root: Path, data: dict[str, list[str]]) -> None:
+    p = _store_path(project_root)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    tmp = p.with_suffix(".json.tmp")
+    tmp.write_text(
+        json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    tmp.replace(p)
+
+
+def load_suppressions(project_root: Path) -> dict[str, set[str]]:
+    """Return ``{doc_rel_path: {lowercased entity name, ...}}`` for the indexer."""
+    return {doc: {e.lower() for e in ents} for doc, ents in _load_raw(project_root).items()}
+
+
+def add_suppression(project_root: Path, document: str, entity: str) -> None:
+    """Suppress the entity↔document link (idempotent, case-insensitive)."""
+    data = _load_raw(project_root)
+    ents = data.setdefault(document, [])
+    if all(e.lower() != entity.lower() for e in ents):
+        ents.append(entity)
+    _save_raw(project_root, data)
+
+
+def remove_suppression(project_root: Path, document: str, entity: str) -> bool:
+    """Remove a suppression (case-insensitive). Returns True if one was removed."""
+    data = _load_raw(project_root)
+    ents = data.get(document, [])
+    kept = [e for e in ents if e.lower() != entity.lower()]
+    if len(kept) == len(ents):
+        return False
+    if kept:
+        data[document] = kept
+    else:
+        data.pop(document, None)
+    _save_raw(project_root, data)
+    return True

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -286,6 +286,28 @@ class TestEntityLinking:
         # "Anders" (5 chars) should now match — threshold lowered to 3
         assert len(david_ids) >= 1
 
+    def test_suppressed_ids_are_not_linked(self, sample_entities):
+        """find_entity_mentions skips entity ids in suppressed_ids (#35)."""
+        from kb.entities import find_entity_mentions
+
+        base = find_entity_mentions(
+            title="Random meeting",
+            tags=[],
+            content="Anders presented the quarterly results.",
+            entities=sample_entities,
+        )
+        base_ids = {m.entity_id for m in base}
+        assert base_ids, "expected at least one match to suppress"
+        target = next(iter(base_ids))
+        suppressed = find_entity_mentions(
+            title="Random meeting",
+            tags=[],
+            content="Anders presented the quarterly results.",
+            entities=sample_entities,
+            suppressed_ids={target},
+        )
+        assert target not in {m.entity_id for m in suppressed}
+
     def test_very_short_name_skipped_in_content(self, sample_entities):
         """Very short single names (<=3 chars) should NOT match in content."""
         from kb.entities import Entity, find_entity_mentions

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1091,6 +1091,52 @@ class TestMcpEntityStale:
 
 
 # ---------------------------------------------------------------------------
+# handle_kb_entity_unlink / handle_kb_entity_relink tests (#35)
+# ---------------------------------------------------------------------------
+
+
+class TestMcpEntityUnlinkRelink:
+    _DOC = "meetings/2026/01/27/mfa_review.notes.md"
+
+    def test_unlink_drops_mention_and_writes_suppression(self, mcp_db):
+        from kb.mcp_server import handle_kb_entity_unlink
+
+        db, root = mcp_db
+        result = json.loads(handle_kb_entity_unlink(db, root, "Talia Ström", self._DOC))
+        assert result["unlinked"] is True
+        assert result["entity"] == "Talia Ström"
+
+        conn = db.get_sqlite_conn()
+        n = conn.execute(
+            "SELECT COUNT(*) AS n FROM entity_mentions WHERE entity_id = 1 AND document_id = 1"
+        ).fetchone()["n"]
+        assert n == 0
+        assert (root / "memory" / ".kbx" / "entity-suppressions.json").is_file()
+
+    def test_relink_removes_suppression(self, mcp_db):
+        from kb.mcp_server import handle_kb_entity_relink, handle_kb_entity_unlink
+
+        db, root = mcp_db
+        handle_kb_entity_unlink(db, root, "Talia Ström", self._DOC)
+        result = json.loads(handle_kb_entity_relink(db, root, "Talia Ström", self._DOC))
+        assert result["relinked"] is True
+
+    def test_unlink_unknown_entity_returns_error(self, mcp_db):
+        from kb.mcp_server import handle_kb_entity_unlink
+
+        db, root = mcp_db
+        result = json.loads(handle_kb_entity_unlink(db, root, "Nobody Here", self._DOC))
+        assert "error" in result
+
+    def test_unlink_unknown_document_returns_error(self, mcp_db):
+        from kb.mcp_server import handle_kb_entity_unlink
+
+        db, root = mcp_db
+        result = json.loads(handle_kb_entity_unlink(db, root, "Talia Ström", "no/such/doc.md"))
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
 # person_find freshness fields
 # ---------------------------------------------------------------------------
 

--- a/tests/test_suppressions.py
+++ b/tests/test_suppressions.py
@@ -1,0 +1,55 @@
+"""Tests for the entity↔document suppression store (kbx #35)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+class TestSuppressionStore:
+    def test_load_missing_returns_empty(self, tmp_path: Path):
+        from kb.suppressions import load_suppressions
+
+        assert load_suppressions(tmp_path) == {}
+
+    def test_add_then_load_normalized(self, tmp_path: Path):
+        from kb.suppressions import add_suppression, load_suppressions
+
+        add_suppression(tmp_path, "memory/meetings/x.md", "Jérémy Cotineau")
+        s = load_suppressions(tmp_path)
+        assert "memory/meetings/x.md" in s
+        # entity names are normalized to lowercase for matching
+        assert "jérémy cotineau" in s["memory/meetings/x.md"]
+
+    def test_add_is_idempotent(self, tmp_path: Path):
+        from kb.suppressions import add_suppression, load_suppressions
+
+        add_suppression(tmp_path, "d.md", "Anders")
+        add_suppression(tmp_path, "d.md", "Anders")
+        assert load_suppressions(tmp_path)["d.md"] == {"anders"}
+
+    def test_remove_case_insensitive(self, tmp_path: Path):
+        from kb.suppressions import add_suppression, load_suppressions, remove_suppression
+
+        add_suppression(tmp_path, "d.md", "Anders")
+        assert remove_suppression(tmp_path, "d.md", "anders") is True
+        assert load_suppressions(tmp_path) == {}
+
+    def test_remove_missing_returns_false(self, tmp_path: Path):
+        from kb.suppressions import remove_suppression
+
+        assert remove_suppression(tmp_path, "d.md", "Nobody") is False
+
+    def test_corrupt_file_is_ignored(self, tmp_path: Path):
+        from kb.suppressions import _store_path, load_suppressions
+
+        p = _store_path(tmp_path)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("{ not json", encoding="utf-8")
+        assert load_suppressions(tmp_path) == {}
+
+    def test_multiple_entities_one_doc(self, tmp_path: Path):
+        from kb.suppressions import add_suppression, load_suppressions
+
+        add_suppression(tmp_path, "d.md", "Anders")
+        add_suppression(tmp_path, "d.md", "Kit")
+        assert load_suppressions(tmp_path)["d.md"] == {"anders", "kit"}

--- a/tests/test_unlink.py
+++ b/tests/test_unlink.py
@@ -1,0 +1,189 @@
+"""Integration tests for entity↔document unlink/relink suppression (#35).
+
+The suppression must survive a full reindex (and, by extension, Granola sync's
+file regeneration) — that persistence is the whole point of the sidecar store.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from kb.cli import cli
+
+
+def _count_mentions(conn: sqlite3.Connection, entity_name: str, doc_like: str) -> int:
+    row = conn.execute(
+        """
+        SELECT COUNT(*) AS n
+        FROM entity_mentions em
+        JOIN entities e ON e.id = em.entity_id
+        JOIN documents d ON d.id = em.document_id
+        WHERE e.name = ? AND d.path LIKE ?
+        """,
+        (entity_name, doc_like),
+    ).fetchone()
+    return int(row["n"])
+
+
+def _seed_project(root: Path) -> str:
+    """Create a person entity + a meeting note that mentions them. Returns note rel-path."""
+    people = root / "memory" / "people"
+    people.mkdir(parents=True)
+    (people / "alex-tanner.md").write_text("# Alex Tanner\n\n**Role:** Engineer\n")
+    meetings = root / "memory" / "meetings" / "2026" / "05" / "24"
+    meetings.mkdir(parents=True)
+    (meetings / "ab12cd34_Sync.granola.notes.md").write_text(
+        "---\ntitle: Sync\ndate: 2026-05-24\ntype: notes\ngranola_id: ab12cd34\n---\n\n"
+        "## Notes\n\nAlex Tanner presented the roadmap.\n"
+    )
+    return "ab12cd34_Sync.granola.notes.md"
+
+
+class TestUnlinkRelink:
+    def test_unlink_drops_mention_and_persists_through_reindex(self, tmp_db):
+        from kb.api import KnowledgeBase
+        from kb.indexer import index_all
+
+        db, _ = tmp_db
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            note = _seed_project(root)
+
+            index_all(db, None, root, full=True)
+            conn = db.get_sqlite_conn()
+            assert _count_mentions(conn, "Alex Tanner", "%Sync%") >= 1, "expected a baseline link"
+
+            kb = KnowledgeBase._from_existing(db=db, project_root=root)
+            result = kb.unlink_entity("Alex Tanner", note)
+            assert result["unlinked"] is True
+            assert result["entity"] == "Alex Tanner"
+            assert _count_mentions(conn, "Alex Tanner", "%Sync%") == 0, "live mention not dropped"
+
+            # The whole point of #35: the suppression survives a full reindex.
+            index_all(db, None, root, full=True)
+            conn = db.get_sqlite_conn()
+            assert _count_mentions(conn, "Alex Tanner", "%Sync%") == 0, (
+                "suppression lost on reindex"
+            )
+
+    def test_relink_restores_mention_on_reindex(self, tmp_db):
+        from kb.api import KnowledgeBase
+        from kb.indexer import index_all
+
+        db, _ = tmp_db
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            note = _seed_project(root)
+
+            index_all(db, None, root, full=True)
+            kb = KnowledgeBase._from_existing(db=db, project_root=root)
+            kb.unlink_entity("Alex Tanner", note)
+            index_all(db, None, root, full=True)
+            conn = db.get_sqlite_conn()
+            assert _count_mentions(conn, "Alex Tanner", "%Sync%") == 0
+
+            result = kb.relink_entity("Alex Tanner", note)
+            assert result["relinked"] is True
+
+            # Re-derivation happens on the next index of the document.
+            index_all(db, None, root, full=True)
+            conn = db.get_sqlite_conn()
+            assert _count_mentions(conn, "Alex Tanner", "%Sync%") >= 1, "link not restored"
+
+    def test_unlink_unknown_entity_raises(self, tmp_db):
+        from kb.api import KnowledgeBase
+        from kb.indexer import index_all
+
+        db, _ = tmp_db
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            note = _seed_project(root)
+            index_all(db, None, root, full=True)
+            kb = KnowledgeBase._from_existing(db=db, project_root=root)
+            try:
+                kb.unlink_entity("Nonexistent Person", note)
+            except ValueError as exc:
+                assert "not found" in str(exc).lower()
+            else:  # pragma: no cover - guard
+                raise AssertionError("expected ValueError for unknown entity")
+
+    def test_unlink_unknown_document_raises(self, tmp_db):
+        from kb.api import KnowledgeBase
+        from kb.indexer import index_all
+
+        db, _ = tmp_db
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            _seed_project(root)
+            index_all(db, None, root, full=True)
+            kb = KnowledgeBase._from_existing(db=db, project_root=root)
+            try:
+                kb.unlink_entity("Alex Tanner", "no-such-document.md")
+            except ValueError as exc:
+                assert "not found" in str(exc).lower()
+            else:  # pragma: no cover - guard
+                raise AssertionError("expected ValueError for unknown document")
+
+
+class TestUnlinkRelinkCLI:
+    def _index(self, root: Path, data_dir: Path) -> None:
+        from kb.db import Database
+        from kb.indexer import index_all
+
+        db = Database(data_dir)
+        index_all(db, None, root, full=True)
+        db.close()
+
+    def test_entity_unlink_then_relink_cli(self, tmp_path):
+        root = tmp_path / "proj"
+        root.mkdir()
+        note = _seed_project(root)
+        data_dir = tmp_path / "data"
+        self._index(root, data_dir)
+
+        with (
+            patch("kb.cli._find_project_root", return_value=root),
+            patch("kb.cli._get_data_dir", return_value=data_dir),
+        ):
+            runner = CliRunner()
+            unlinked = runner.invoke(
+                cli,
+                ["entity", "unlink", "Alex Tanner", note, "--no-commit", "--json"],
+                catch_exceptions=False,
+            )
+            assert unlinked.exit_code == 0, unlinked.output
+            assert json.loads(unlinked.output)["unlinked"] is True
+
+            relinked = runner.invoke(
+                cli,
+                ["entity", "relink", "Alex Tanner", note, "--no-commit", "--json"],
+                catch_exceptions=False,
+            )
+            assert relinked.exit_code == 0, relinked.output
+            assert json.loads(relinked.output)["relinked"] is True
+
+    def test_entity_unlink_unknown_entity_exits_nonzero(self, tmp_path):
+        root = tmp_path / "proj"
+        root.mkdir()
+        note = _seed_project(root)
+        data_dir = tmp_path / "data"
+        self._index(root, data_dir)
+
+        with (
+            patch("kb.cli._find_project_root", return_value=root),
+            patch("kb.cli._get_data_dir", return_value=data_dir),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli,
+                ["entity", "unlink", "Ghost Person", note, "--no-commit"],
+                catch_exceptions=False,
+            )
+            assert result.exit_code == 1
+            assert "not found" in result.output.lower()


### PR DESCRIPTION
## What

Adds a way to suppress false-positive entity↔document links that survives re-indexing and Granola sync.

- New sidecar store `memory/.kbx/entity-suppressions.json` (`src/kb/suppressions.py`) — keyed by document path → entity names, case-insensitive, atomic writes.
- `find_entity_mentions(..., suppressed_ids=...)` skips suppressed entities across **all** matching tiers.
- Indexer loads the sidecar, maps suppressed entity names→ids per document, and threads `suppressed_ids` into mention derivation — so the fix persists through a full re-index (names, not ids, are the key).
- `KnowledgeBase.unlink_entity()` / `relink_entity()` API methods (drop the live mention now + record/remove the suppression).
- CLI: `kbx entity unlink "Name" <doc>` / `kbx entity relink "Name" <doc>` (auto-commit aware).
- MCP: `kb_entity_unlink` / `kb_entity_relink` (both idempotent).

## Why

Entity linking is heuristic and occasionally wrong (a bare first name matching the wrong person, a title substring that isn't really about the entity). Mentions are re-derived on every index and Granola sync regenerates meeting files, so a correction couldn't live in the DB row or in frontmatter — it would be wiped on the next sync. A sidecar keyed by entity *name* is the only place a suppression survives id churn + file regeneration.

## Tests

- `test_suppressions.py` — store unit tests (load/add/remove, idempotency, corrupt-file tolerance).
- `test_unlink.py` — full integration through `index_all`: unlink drops the mention **and stays dropped across a full reindex**; relink restores it; CLI happy-path + error paths.
- `test_entities.py` — matcher honours `suppressed_ids`.
- `test_mcp.py` — `kb_entity_unlink`/`kb_entity_relink` handlers (success + error shapes).

Docs updated: `docs/entities.md` (new §Suppressions), `docs/cli.md`, `CLAUDE.md` (tool count 31→33 + MCP section), CLI `_AGENT_PLAYBOOK`.

Closes #35.